### PR TITLE
Add NCPDP vF6 telecommunication format support

### DIFF
--- a/pkg/claimDeserializer/bench_test.go
+++ b/pkg/claimDeserializer/bench_test.go
@@ -1,0 +1,22 @@
+package claimdeserializer
+
+import "testing"
+
+func Benchmark_DeserializeB1(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := Deserialize(REQUEST_B1)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func Benchmark_DeserializeF6Full(b *testing.B) {
+	raw := buildF6FullBillingRequest()
+	for i := 0; i < b.N; i++ {
+		_, err := Deserialize(raw)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/claimDeserializer/claimDeserializer.go
+++ b/pkg/claimDeserializer/claimDeserializer.go
@@ -23,6 +23,7 @@ const (
 const (
 	dZeroRequestLength  = 56
 	dZeroResponseLength = 31
+	f6RequestLength     = 58
 )
 
 // Parse raw data.
@@ -39,7 +40,7 @@ func Deserialize(rawClaimString string) (interface{}, error) {
 	}
 
 	// Assume request
-	if firstSeparatorIndex == dZeroRequestLength {
+	if firstSeparatorIndex == dZeroRequestLength || firstSeparatorIndex == f6RequestLength {
 		return DeserializeRequest(rawClaimString)
 	}
 
@@ -64,7 +65,12 @@ func DeserializeRequest(rawClaimString string) (interface{}, error) {
 		return nil, fmt.Errorf("unable to determine transaction type")
 	}
 
+	// D0 request headers lead with the BIN (digits); F6 headers lead with the
+	// version (e.g. "F6"), which moves the transaction code to bytes 2-4.
 	tranCode := rawClaimString[8:10]
+	if rawClaimString[0] == 'F' {
+		tranCode = rawClaimString[2:4]
+	}
 
 	claimType, err := serde.GetRequestType(tranCode)
 	if err != nil {
@@ -141,11 +147,25 @@ func deserializeRaw(rawClaimString string, claimType reflect.Type, claimObjectRe
 	// Set header
 	evaluateHeader(rawClaimString, claimType, claimObjectRef)
 
+	groupIndex := stringutils.IndexOfAny(rawClaimString, 0, []byte{ncpdp.GROUP})
+
+	if groupIndex < 0 && strings.HasPrefix(rawClaimString, "F") {
+		// vEB+ (e.g. F6) eliminated the group separator and allows only a single
+		// transaction per transmission; the claim segments directly follow the
+		// shared segments and are located by segment ID instead.
+		err := evaluateUngroupedTransaction(rawClaimString, claimType, claimObjectRef)
+		if err != nil {
+			return nil, err
+		}
+
+		return claimObjectRef.Interface(), nil
+	}
+
 	// Set group data
 	evaluateGrouping(rawClaimString, claimType, claimObjectRef)
 
 	// Set shared segment data
-	endIndex := stringutils.IndexOfAny(rawClaimString, 0, []byte{ncpdp.GROUP})
+	endIndex := groupIndex
 	if endIndex <= 0 {
 		endIndex = len(rawClaimString)
 	}
@@ -239,6 +259,92 @@ func evaluateGrouping(rawClaimString string, structType reflect.Type, structVal 
 	}
 
 	return nil
+}
+
+// Evaluate an ungrouped (vEB+/F6) transmission. No group separators exist, so
+// the single transaction's segments are located by segment ID: the first
+// segment that belongs to the claim group struct starts the transaction, and
+// it plus everything after it parse as one claim group. Segments before it
+// parse as shared segments.
+func evaluateUngroupedTransaction(rawClaimString string, structType reflect.Type, structVal reflect.Value) error {
+	groupField, err := serde.GetGroupSlice(structType)
+	if err != nil {
+		return err
+	}
+
+	transactionIndex := -1
+
+	if groupField != nil {
+		groupElementType := groupField.Type.Elem()
+
+		groupSegmentMap, err := serde.GetSegmentDefinitionById(reflectionutils.GetElementType(groupElementType))
+		if err != nil {
+			return err
+		}
+
+		segIndex := stringutils.IndexOfAny(rawClaimString, 0, []byte{ncpdp.SEGMENT})
+		for segIndex != -1 {
+			nextIndex := stringutils.IndexOfAny(rawClaimString, segIndex+1, []byte{ncpdp.SEGMENT})
+
+			endIndex := len(rawClaimString)
+			if nextIndex != -1 {
+				endIndex = nextIndex
+			}
+
+			if _, ok := groupSegmentMap[segmentIdOf(rawClaimString[segIndex+1:endIndex])]; ok {
+				transactionIndex = segIndex
+				break
+			}
+
+			segIndex = nextIndex
+		}
+	}
+
+	sharedRaw := rawClaimString
+	if transactionIndex != -1 {
+		sharedRaw = rawClaimString[:transactionIndex]
+	}
+
+	err = evaluateSegments(sharedRaw, structType, structVal)
+	if err != nil {
+		return err
+	}
+
+	if transactionIndex == -1 {
+		return nil
+	}
+
+	transactionRaw := rawClaimString[transactionIndex:]
+
+	groupElementType := groupField.Type.Elem()
+	groupItem := reflect.New(groupElementType).Elem()
+
+	initializeStruct(groupElementType, groupItem)
+
+	setStructFieldByCodeTag(groupElementType, groupItem, rawGroupTag, reflect.ValueOf(transactionRaw), 0, 0, false)
+
+	err = evaluateSegments(transactionRaw, groupElementType, groupItem)
+	if err != nil {
+		return err
+	}
+
+	baseVal := reflectionutils.GetElementValue(structVal)
+	groupSlice := baseVal.FieldByName(groupField.Name)
+	groupSlice.Set(reflect.Append(groupSlice, groupItem))
+
+	return nil
+}
+
+// segmentIdOf returns the segment ID field (e.g. "AM07") of a raw segment.
+func segmentIdOf(rawSeg string) string {
+	rawFields := stringutils.SplitBySeparator(rawSeg, ncpdp.FIELD)
+
+	idIndex := sliceutils.IndexOfStartsWith(ncpdp.SEGMENT_FIELD_ID, rawFields)
+	if idIndex < 0 {
+		return serde.Empty
+	}
+
+	return rawFields[idIndex]
 }
 
 // Add elements to dynamic field list.

--- a/pkg/claimDeserializer/claimDeserializer.go
+++ b/pkg/claimDeserializer/claimDeserializer.go
@@ -272,32 +272,9 @@ func evaluateUngroupedTransaction(rawClaimString string, structType reflect.Type
 		return err
 	}
 
-	transactionIndex := -1
-
-	if groupField != nil {
-		groupElementType := groupField.Type.Elem()
-
-		groupSegmentMap, err := serde.GetSegmentDefinitionById(reflectionutils.GetElementType(groupElementType))
-		if err != nil {
-			return err
-		}
-
-		segIndex := stringutils.IndexOfAny(rawClaimString, 0, []byte{ncpdp.SEGMENT})
-		for segIndex != -1 {
-			nextIndex := stringutils.IndexOfAny(rawClaimString, segIndex+1, []byte{ncpdp.SEGMENT})
-
-			endIndex := len(rawClaimString)
-			if nextIndex != -1 {
-				endIndex = nextIndex
-			}
-
-			if _, ok := groupSegmentMap[segmentIdOf(rawClaimString[segIndex+1:endIndex])]; ok {
-				transactionIndex = segIndex
-				break
-			}
-
-			segIndex = nextIndex
-		}
+	transactionIndex, err := findTransactionIndex(rawClaimString, groupField)
+	if err != nil {
+		return err
 	}
 
 	sharedRaw := rawClaimString
@@ -333,6 +310,38 @@ func evaluateUngroupedTransaction(rawClaimString string, structType reflect.Type
 	groupSlice.Set(reflect.Append(groupSlice, groupItem))
 
 	return nil
+}
+
+// findTransactionIndex locates the start of the single (vEB+) claim group: the
+// first segment whose ID belongs to the group struct. Returns -1 when the
+// struct has no group slice or no segment matches.
+func findTransactionIndex(rawClaimString string, groupField *reflect.StructField) (int, error) {
+	if groupField == nil {
+		return -1, nil
+	}
+
+	groupSegmentMap, err := serde.GetSegmentDefinitionById(reflectionutils.GetElementType(groupField.Type.Elem()))
+	if err != nil {
+		return -1, err
+	}
+
+	segIndex := stringutils.IndexOfAny(rawClaimString, 0, []byte{ncpdp.SEGMENT})
+	for segIndex != -1 {
+		nextIndex := stringutils.IndexOfAny(rawClaimString, segIndex+1, []byte{ncpdp.SEGMENT})
+
+		endIndex := len(rawClaimString)
+		if nextIndex != -1 {
+			endIndex = nextIndex
+		}
+
+		if _, ok := groupSegmentMap[segmentIdOf(rawClaimString[segIndex+1:endIndex])]; ok {
+			return segIndex, nil
+		}
+
+		segIndex = nextIndex
+	}
+
+	return -1, nil
 }
 
 // segmentIdOf returns the segment ID field (e.g. "AM07") of a raw segment.

--- a/pkg/claimDeserializer/claimDeserializer.go
+++ b/pkg/claimDeserializer/claimDeserializer.go
@@ -249,7 +249,7 @@ func evaluateGrouping(rawClaimString string, structType reflect.Type, structVal 
 		initializeStruct(groupElementType, groupItem)
 
 		// Set field defined as "raw" data tag
-		setStructFieldByCodeTag(groupElementType, groupItem, rawGroupTag, reflect.ValueOf(fmt.Sprint(string(ncpdp.GROUP), rawClaimGroup)), 0, 0, false)
+		setStructFieldByCodeTag(groupElementType, groupItem, rawGroupTag, reflect.ValueOf(string(ncpdp.GROUP)+rawClaimGroup), 0, 0, false)
 
 		// Set segment data
 		evaluateSegments(rawClaimGroup, groupElementType, groupItem)
@@ -437,12 +437,12 @@ func evaluateSegments(rawData string, structType reflect.Type, structVal reflect
 	baseType := reflectionutils.GetElementType(structType)
 	baseVal := reflectionutils.GetElementValue(structVal)
 
-	for _, rawSeg := range rawSegments {
-		segmentMap, err := serde.GetSegmentDefinitionById(baseType)
-		if err != nil {
-			return err
-		}
+	segmentMap, err := serde.GetSegmentDefinitionById(baseType)
+	if err != nil {
+		return err
+	}
 
+	for _, rawSeg := range rawSegments {
 		// Get all fields
 		rawFields := stringutils.SplitBySeparator(rawSeg, ncpdp.FIELD)
 
@@ -478,7 +478,7 @@ func evaluateSegments(rawData string, structType reflect.Type, structVal reflect
 		initializeStruct(elementType, segment)
 
 		// Set field defined as "raw" data tag
-		setStructFieldByCodeTag(elementType, segment, rawSegmentTag, reflect.ValueOf(fmt.Sprint(string(ncpdp.SEGMENT), rawSeg)), 0, 0, false)
+		setStructFieldByCodeTag(elementType, segment, rawSegmentTag, reflect.ValueOf(string(ncpdp.SEGMENT)+rawSeg), 0, 0, false)
 
 		fieldCountMap := map[string]int{}
 

--- a/pkg/claimDeserializer/claimDeserializer_test.go
+++ b/pkg/claimDeserializer/claimDeserializer_test.go
@@ -545,37 +545,19 @@ func Test_CanParseF6BillingRequest(t *testing.T) {
 	}
 
 	header := obj.Header.Value
-	if header.Version != ncpdp.F6 {
-		t.Errorf("Version mismatch. Wanted: F6   Got: %q", header.Version)
-	}
-	if header.Bin != "00880151" {
-		t.Errorf("Bin/IIN mismatch. Wanted: 00880151   Got: %q", header.Bin)
-	}
-	if header.TransactionCode != "B1" {
-		t.Errorf("TransactionCode mismatch. Wanted: B1   Got: %q", header.TransactionCode)
-	}
-	if header.Pcn != "TEST" {
-		t.Errorf("Pcn mismatch. Wanted: TEST   Got: %q", header.Pcn)
-	}
-	if header.RecordCount != 1 {
-		t.Errorf("RecordCount mismatch. Wanted: 1   Got: %v", header.RecordCount)
-	}
-	if obj.Header.Size != 58 {
-		t.Errorf("Header size mismatch. Wanted: 58   Got: %v", obj.Header.Size)
-	}
+	assertValue(t, "Version", header.Version, ncpdp.F6)
+	assertValue(t, "Bin/IIN", header.Bin, "00880151")
+	assertValue(t, "TransactionCode", header.TransactionCode, "B1")
+	assertValue(t, "Pcn", header.Pcn, "TEST")
+	assertValue(t, "RecordCount", header.RecordCount, 1)
+	assertValue(t, "Header size", obj.Header.Size, 58)
 
-	if obj.Patient.FirstName == nil || *obj.Patient.FirstName != "JOHN" {
-		t.Errorf("Patient first name mismatch. Wanted: JOHN   Got: %v", obj.Patient.FirstName)
-	}
-	if obj.Patient.MiddleName == nil || *obj.Patient.MiddleName != "QUINCY" {
-		t.Errorf("Patient middle name (F6 field 0C) mismatch. Wanted: QUINCY   Got: %v", obj.Patient.MiddleName)
-	}
+	assertString(t, "Patient first name", obj.Patient.FirstName, "JOHN")
+	assertString(t, "Patient middle name (F6 field 0C)", obj.Patient.MiddleName, "QUINCY")
 
 	// Repeating patient ID (F6): scalars keep one occurrence for backward
 	// compatibility, the Ids slice captures every occurrence.
-	if obj.Patient.IdCount == nil || *obj.Patient.IdCount != 2 {
-		t.Errorf("Patient id count (F6 field RR) mismatch. Wanted: 2   Got: %v", obj.Patient.IdCount)
-	}
+	assertInt(t, "Patient id count (F6 field RR)", obj.Patient.IdCount, 2)
 	if obj.Patient.Id == nil || obj.Patient.IdQualifier == nil {
 		t.Error("Patient scalar Id/IdQualifier not populated")
 	}
@@ -583,30 +565,21 @@ func Test_CanParseF6BillingRequest(t *testing.T) {
 		t.Fatalf("Patient ids count mismatch. Wanted: 2   Got: %v", len(obj.Patient.Ids))
 	}
 	for i, want := range []struct{ qualifier, id string }{{"01", "111111111"}, {"02", "222222222"}} {
-		got := obj.Patient.Ids[i]
-		if got.Qualifier == nil || *got.Qualifier != want.qualifier || got.Id == nil || *got.Id != want.id {
-			t.Errorf("Patient ids[%d] mismatch. Wanted: %s/%s   Got: %v/%v", i, want.qualifier, want.id, got.Qualifier, got.Id)
-		}
+		assertString(t, fmt.Sprintf("Patient ids[%d] qualifier", i), obj.Patient.Ids[i].Qualifier, want.qualifier)
+		assertString(t, fmt.Sprintf("Patient ids[%d] id", i), obj.Patient.Ids[i].Id, want.id)
 	}
 
 	if len(obj.Claims) != 1 {
 		t.Fatalf("Group count mismatch. Wanted: 1   Got: %v", len(obj.Claims))
 	}
 
-	claim := obj.Claims[0]
-	intermediary := claim.Intermediary
-	if intermediary.IdCount == nil || *intermediary.IdCount != 1 {
-		t.Errorf("Intermediary id count (F6 field 8G) mismatch. Wanted: 1   Got: %v", intermediary.IdCount)
-	}
+	intermediary := obj.Claims[0].Intermediary
+	assertInt(t, "Intermediary id count (F6 field 8G)", intermediary.IdCount, 1)
 	if len(intermediary.Ids) != 1 {
 		t.Fatalf("Intermediary ids (F6 segment AM19) count mismatch. Wanted: 1   Got: %v", len(intermediary.Ids))
 	}
-	if intermediary.Ids[0].Qualifier == nil || *intermediary.Ids[0].Qualifier != "QQ" {
-		t.Errorf("Intermediary id qualifier (F6 field 8K) mismatch. Wanted: QQ   Got: %v", intermediary.Ids[0].Qualifier)
-	}
-	if intermediary.Ids[0].Id == nil || *intermediary.Ids[0].Id != "INTERMEDIARY01" {
-		t.Errorf("Intermediary id (F6 field 8M) mismatch. Wanted: INTERMEDIARY01   Got: %v", intermediary.Ids[0].Id)
-	}
+	assertString(t, "Intermediary id qualifier (F6 field 8K)", intermediary.Ids[0].Qualifier, "QQ")
+	assertString(t, "Intermediary id (F6 field 8M)", intermediary.Ids[0].Id, "INTERMEDIARY01")
 }
 
 func Test_CanParseF6BillingResponse(t *testing.T) {
@@ -663,6 +636,22 @@ func buildF6FullBillingRequest() string {
 		ss + fs + "AM11" + fs + "D91234567H" + fs + "DC250{" + fs + "BE200{" + fs + "DX" + fs + "E350{" + fs + "H71" + fs + "H801" + fs + "H975E" + fs + "RK1" + fs + "RLAB" + fs + "HA43B" + fs + "GE12345G" + fs + "HE10000" + fs + "JE02" + fs + "DQ1345670{" + fs + "DU1247532B" + fs + "DN01"
 }
 
+func assertValue[T comparable](t *testing.T, name string, got, want T) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s mismatch. Wanted: %v   Got: %v", name, want, got)
+	}
+}
+
+func assertInt(t *testing.T, name string, got *int, want int) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("%s mismatch. Wanted: %v   Got: nil", name, want)
+	} else if *got != want {
+		t.Errorf("%s mismatch. Wanted: %v   Got: %v", name, want, *got)
+	}
+}
+
 func assertString(t *testing.T, name string, got *string, want string) {
 	t.Helper()
 	if got == nil {
@@ -692,37 +681,35 @@ func Test_CanParseF6FullFieldSample(t *testing.T) {
 		t.Fatalf("expected request.Billing, got: %T", i)
 	}
 
+	assertF6FullSampleHeader(t, obj)
+	assertF6FullSampleInsurance(t, obj)
+	assertF6FullSamplePatient(t, obj)
+
+	if len(obj.Claims) != 1 {
+		t.Fatalf("Group count mismatch. Wanted: 1   Got: %v", len(obj.Claims))
+	}
+
+	assertF6FullSamplePricing(t, obj)
+}
+
+func assertF6FullSampleHeader(t *testing.T, obj request.Billing) {
+	t.Helper()
+
 	header := obj.Header.Value
-	if header.Version != ncpdp.F6 {
-		t.Errorf("Version mismatch. Wanted: F6   Got: %q", header.Version)
-	}
-	if header.Bin != "88015600" {
-		t.Errorf("Bin/IIN mismatch. Wanted: 88015600   Got: %q", header.Bin)
-	}
-	if header.TransactionCode != "B1" {
-		t.Errorf("TransactionCode mismatch. Wanted: B1   Got: %q", header.TransactionCode)
-	}
-	if header.Pcn != "PCN1234567" {
-		t.Errorf("Pcn mismatch. Wanted: PCN1234567   Got: %q", header.Pcn)
-	}
-	if header.RecordCount != 1 {
-		t.Errorf("RecordCount mismatch. Wanted: 1   Got: %v", header.RecordCount)
-	}
-	if header.ServiceProviderIdQualifier != "01" {
-		t.Errorf("ServiceProviderIdQualifier mismatch. Wanted: 01   Got: %q", header.ServiceProviderIdQualifier)
-	}
-	if header.ServiceProviderId != "1234567893" {
-		t.Errorf("ServiceProviderId mismatch. Wanted: 1234567893   Got: %q", header.ServiceProviderId)
-	}
-	if header.DateOfService != "20260611" {
-		t.Errorf("DateOfService mismatch. Wanted: 20260611   Got: %q", header.DateOfService)
-	}
-	if header.SoftwareVendorCertificationId != "VENDORCERT" {
-		t.Errorf("SoftwareVendorCertificationId mismatch. Wanted: VENDORCERT   Got: %q", header.SoftwareVendorCertificationId)
-	}
-	if obj.Header.Size != 58 {
-		t.Errorf("Header size mismatch. Wanted: 58   Got: %v", obj.Header.Size)
-	}
+	assertValue(t, "Version", header.Version, ncpdp.F6)
+	assertValue(t, "Bin/IIN", header.Bin, "88015600")
+	assertValue(t, "TransactionCode", header.TransactionCode, "B1")
+	assertValue(t, "Pcn", header.Pcn, "PCN1234567")
+	assertValue(t, "RecordCount", header.RecordCount, 1)
+	assertValue(t, "ServiceProviderIdQualifier", header.ServiceProviderIdQualifier, "01")
+	assertValue(t, "ServiceProviderId", header.ServiceProviderId, "1234567893")
+	assertValue(t, "DateOfService", header.DateOfService, "20260611")
+	assertValue(t, "SoftwareVendorCertificationId", header.SoftwareVendorCertificationId, "VENDORCERT")
+	assertValue(t, "Header size", obj.Header.Size, 58)
+}
+
+func assertF6FullSampleInsurance(t *testing.T, obj request.Billing) {
+	t.Helper()
 
 	insurance := obj.Insurance
 	assertString(t, "Insurance cardholder id (C2)", insurance.Cardholder.Id, "CARDID")
@@ -740,11 +727,13 @@ func Test_CanParseF6FullFieldSample(t *testing.T) {
 	if len(insurance.DynamicFields) != 0 {
 		t.Errorf("Insurance dynamic field spillover. Wanted: 0   Got: %v", len(insurance.DynamicFields))
 	}
+}
+
+func assertF6FullSamplePatient(t *testing.T, obj request.Billing) {
+	t.Helper()
 
 	patient := obj.Patient
-	if patient.IdCount == nil || *patient.IdCount != 1 {
-		t.Errorf("Patient id count (RR) mismatch. Wanted: 1   Got: %v", patient.IdCount)
-	}
+	assertInt(t, "Patient id count (RR)", patient.IdCount, 1)
 	assertString(t, "Patient id qualifier (CX)", patient.IdQualifier, "99")
 	assertString(t, "Patient id (CY)", patient.Id, "PATIENTID")
 	if len(patient.Ids) != 1 {
@@ -775,10 +764,10 @@ func Test_CanParseF6FullFieldSample(t *testing.T) {
 	if len(patient.DynamicFields) != 0 {
 		t.Errorf("Patient dynamic field spillover. Wanted: 0   Got: %v", len(patient.DynamicFields))
 	}
+}
 
-	if len(obj.Claims) != 1 {
-		t.Fatalf("Group count mismatch. Wanted: 1   Got: %v", len(obj.Claims))
-	}
+func assertF6FullSamplePricing(t *testing.T, obj request.Billing) {
+	t.Helper()
 
 	pricing := obj.Claims[0].Pricing
 	assertFloat(t, "Pricing ingredient cost (D9)", pricing.IngredientCostSubmitted, 123456.78)

--- a/pkg/claimDeserializer/claimDeserializer_test.go
+++ b/pkg/claimDeserializer/claimDeserializer_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp"
 	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp/request"
 	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp/response"
 )
@@ -499,5 +500,383 @@ func Test_CanParseUndefinedReversalSegments(t *testing.T) {
 		}
 
 		fmt.Print(string(bytes))
+	}
+}
+
+// F6 request header is 58 bytes: version(2) tranCode(2) IIN(8) PCN(10) recordCount(1) SPIQ(2) SPI(15) DOS(8) vendorCertId(10)
+const F6_REQUEST_B1_HEADER = "F6B100880151TEST      1011234567893     20260611SVCID     "
+
+// Raw test constants embed invisible separator bytes, so the F6 sample is
+// built programmatically. F6 (vEB+) has no group separators; the single
+// transaction's segments directly follow the shared segments.
+func buildF6BillingRequest() string {
+	fs := string(ncpdp.FIELD)
+	ss := string(ncpdp.SEGMENT)
+
+	return F6_REQUEST_B1_HEADER +
+		ss + fs + "AM04" + fs + "C2POLICY123" + fs + "C1TESTGROUP" + fs + "C61" +
+		ss + fs + "AM01" + fs + "RR2" + fs + "CX01" + fs + "CY111111111" + fs + "CX02" + fs + "CY222222222" + fs + "C419341231" + fs + "C51" + fs + "CAJOHN" + fs + "0CQUINCY" + fs + "CBDOE" +
+		ss + fs + "AM07" + fs + "EM1" + fs + "D26000001" + fs + "E103" + fs + "D700172240780" + fs + "E70000001000" + fs + "D300" + fs + "D530" + fs + "D61" + fs + "D80" + fs + "DE20260611" + fs + "U701" +
+		ss + fs + "AM19" + fs + "8G1" + fs + "8H01" + fs + "8KQQ" + fs + "8MINTERMEDIARY01"
+}
+
+// F6 response header layout is identical to D0 (31 bytes).
+const F6_RESPONSE_B1_HEADER = "F6B11A011234567893     20260611"
+
+func buildF6BillingResponse() string {
+	fs := string(ncpdp.FIELD)
+	ss := string(ncpdp.SEGMENT)
+
+	return F6_RESPONSE_B1_HEADER +
+		ss + fs + "AM25" + fs + "C1TESTGROUP" + fs + "KR2" + fs + "J701" + fs + "J8PAYER001" + fs + "J702" + fs + "J8PAYER002" + fs + "C2CARD123" +
+		ss + fs + "AM21" + fs + "ANA" +
+		ss + fs + "AM22" + fs + "EM1" + fs + "D26000001"
+}
+
+func Test_CanParseF6BillingRequest(t *testing.T) {
+	i, err := Deserialize(buildF6BillingRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	obj, ok := i.(request.Billing)
+	if !ok {
+		t.Fatalf("expected request.Billing, got: %T", i)
+	}
+
+	header := obj.Header.Value
+	if header.Version != ncpdp.F6 {
+		t.Errorf("Version mismatch. Wanted: F6   Got: %q", header.Version)
+	}
+	if header.Bin != "00880151" {
+		t.Errorf("Bin/IIN mismatch. Wanted: 00880151   Got: %q", header.Bin)
+	}
+	if header.TransactionCode != "B1" {
+		t.Errorf("TransactionCode mismatch. Wanted: B1   Got: %q", header.TransactionCode)
+	}
+	if header.Pcn != "TEST" {
+		t.Errorf("Pcn mismatch. Wanted: TEST   Got: %q", header.Pcn)
+	}
+	if header.RecordCount != 1 {
+		t.Errorf("RecordCount mismatch. Wanted: 1   Got: %v", header.RecordCount)
+	}
+	if obj.Header.Size != 58 {
+		t.Errorf("Header size mismatch. Wanted: 58   Got: %v", obj.Header.Size)
+	}
+
+	if obj.Patient.FirstName == nil || *obj.Patient.FirstName != "JOHN" {
+		t.Errorf("Patient first name mismatch. Wanted: JOHN   Got: %v", obj.Patient.FirstName)
+	}
+	if obj.Patient.MiddleName == nil || *obj.Patient.MiddleName != "QUINCY" {
+		t.Errorf("Patient middle name (F6 field 0C) mismatch. Wanted: QUINCY   Got: %v", obj.Patient.MiddleName)
+	}
+
+	// Repeating patient ID (F6): scalars keep one occurrence for backward
+	// compatibility, the Ids slice captures every occurrence.
+	if obj.Patient.IdCount == nil || *obj.Patient.IdCount != 2 {
+		t.Errorf("Patient id count (F6 field RR) mismatch. Wanted: 2   Got: %v", obj.Patient.IdCount)
+	}
+	if obj.Patient.Id == nil || obj.Patient.IdQualifier == nil {
+		t.Error("Patient scalar Id/IdQualifier not populated")
+	}
+	if len(obj.Patient.Ids) != 2 {
+		t.Fatalf("Patient ids count mismatch. Wanted: 2   Got: %v", len(obj.Patient.Ids))
+	}
+	for i, want := range []struct{ qualifier, id string }{{"01", "111111111"}, {"02", "222222222"}} {
+		got := obj.Patient.Ids[i]
+		if got.Qualifier == nil || *got.Qualifier != want.qualifier || got.Id == nil || *got.Id != want.id {
+			t.Errorf("Patient ids[%d] mismatch. Wanted: %s/%s   Got: %v/%v", i, want.qualifier, want.id, got.Qualifier, got.Id)
+		}
+	}
+
+	if len(obj.Claims) != 1 {
+		t.Fatalf("Group count mismatch. Wanted: 1   Got: %v", len(obj.Claims))
+	}
+
+	claim := obj.Claims[0]
+	intermediary := claim.Intermediary
+	if intermediary.IdCount == nil || *intermediary.IdCount != 1 {
+		t.Errorf("Intermediary id count (F6 field 8G) mismatch. Wanted: 1   Got: %v", intermediary.IdCount)
+	}
+	if len(intermediary.Ids) != 1 {
+		t.Fatalf("Intermediary ids (F6 segment AM19) count mismatch. Wanted: 1   Got: %v", len(intermediary.Ids))
+	}
+	if intermediary.Ids[0].Qualifier == nil || *intermediary.Ids[0].Qualifier != "QQ" {
+		t.Errorf("Intermediary id qualifier (F6 field 8K) mismatch. Wanted: QQ   Got: %v", intermediary.Ids[0].Qualifier)
+	}
+	if intermediary.Ids[0].Id == nil || *intermediary.Ids[0].Id != "INTERMEDIARY01" {
+		t.Errorf("Intermediary id (F6 field 8M) mismatch. Wanted: INTERMEDIARY01   Got: %v", intermediary.Ids[0].Id)
+	}
+}
+
+func Test_CanParseF6BillingResponse(t *testing.T) {
+	i, err := Deserialize(buildF6BillingResponse())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	obj, ok := i.(response.Billing)
+	if !ok {
+		t.Fatalf("expected response.Billing, got: %T", i)
+	}
+
+	if obj.Header.Value.Version != ncpdp.F6 {
+		t.Errorf("Version mismatch. Wanted: F6   Got: %q", obj.Header.Value.Version)
+	}
+
+	// Repeating payer ID (F6): the singular Payer keeps one occurrence for
+	// backward compatibility, the Payers slice captures every occurrence.
+	insurance := obj.Insurance
+	if insurance.PayerIdCount == nil || *insurance.PayerIdCount != 2 {
+		t.Errorf("Payer id count (F6 field KR) mismatch. Wanted: 2   Got: %v", insurance.PayerIdCount)
+	}
+	if insurance.Payer.Id == nil || insurance.Payer.Qualifier == nil {
+		t.Error("Singular Payer not populated")
+	}
+	if len(insurance.Payers) != 2 {
+		t.Fatalf("Payers count mismatch. Wanted: 2   Got: %v", len(insurance.Payers))
+	}
+	for i, want := range []struct{ qualifier, id string }{{"01", "PAYER001"}, {"02", "PAYER002"}} {
+		got := insurance.Payers[i]
+		if got.Qualifier == nil || *got.Qualifier != want.qualifier || got.Id == nil || *got.Id != want.id {
+			t.Errorf("Payers[%d] mismatch. Wanted: %s/%s   Got: %v/%v", i, want.qualifier, want.id, got.Qualifier, got.Id)
+		}
+	}
+
+	if len(obj.Claims) != 1 {
+		t.Fatalf("Group count mismatch. Wanted: 1   Got: %v", len(obj.Claims))
+	}
+}
+
+const F6_REQUEST_FULL_HEADER = "F6B188015600PCN12345671011234567893     20260611VENDORCERT"
+
+// Built from the raw F6 sample (RawSample_F6.txt) with CRLF line breaks
+// removed. F6 has no group separator: AM11 follows the shared segments
+// directly and is assigned to the single claim group by segment ID.
+func buildF6FullBillingRequest() string {
+	fs := string(ncpdp.FIELD)
+	ss := string(ncpdp.SEGMENT)
+
+	return F6_REQUEST_FULL_HEADER +
+		ss + fs + "AM04" + fs + "C2CARDID" + fs + "CCCARDFIRST" + fs + "CDCARDLAST" + fs + "FOPLANID" + fs + "C90" + fs + "C1D0PAID" + fs + "C3001" + fs + "C61" + fs + "2AMEDIGAPID" + fs + "2BSC" + fs + "2DN" + fs + "N5MEDICAIDIDNUMBER" +
+		ss + fs + "AM01" + fs + "RR1" + fs + "CX99" + fs + "CYPATIENTID" + fs + "C419850601" + fs + "C51" + fs + "CAFIRSTNAME" + fs + "CBLASTNAME" + fs + "7A1234 FIRST ADDRESS LINE" + fs + "7B7890 SECOND ADDRESS LINE" + fs + "CNROEBUCK" + fs + "COSC" + fs + "CP293764444" + fs + "1KUS" + fs + "CQ8645555555" + fs + "C701" + fs + "CZEMPLOYERID" + fs + "2C1" + fs + "HNEMAIL@DOMAIN.COM" + fs + "4X1" + fs + "S8337915000" +
+		ss + fs + "AM11" + fs + "D91234567H" + fs + "DC250{" + fs + "BE200{" + fs + "DX" + fs + "E350{" + fs + "H71" + fs + "H801" + fs + "H975E" + fs + "RK1" + fs + "RLAB" + fs + "HA43B" + fs + "GE12345G" + fs + "HE10000" + fs + "JE02" + fs + "DQ1345670{" + fs + "DU1247532B" + fs + "DN01"
+}
+
+func assertString(t *testing.T, name string, got *string, want string) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("%s mismatch. Wanted: %q   Got: nil", name, want)
+	} else if *got != want {
+		t.Errorf("%s mismatch. Wanted: %q   Got: %q", name, want, *got)
+	}
+}
+
+func assertFloat(t *testing.T, name string, got *float64, want float64) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("%s mismatch. Wanted: %v   Got: nil", name, want)
+	} else if *got != want {
+		t.Errorf("%s mismatch. Wanted: %v   Got: %v", name, want, *got)
+	}
+}
+
+func Test_CanParseF6FullFieldSample(t *testing.T) {
+	i, err := Deserialize(buildF6FullBillingRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	obj, ok := i.(request.Billing)
+	if !ok {
+		t.Fatalf("expected request.Billing, got: %T", i)
+	}
+
+	header := obj.Header.Value
+	if header.Version != ncpdp.F6 {
+		t.Errorf("Version mismatch. Wanted: F6   Got: %q", header.Version)
+	}
+	if header.Bin != "88015600" {
+		t.Errorf("Bin/IIN mismatch. Wanted: 88015600   Got: %q", header.Bin)
+	}
+	if header.TransactionCode != "B1" {
+		t.Errorf("TransactionCode mismatch. Wanted: B1   Got: %q", header.TransactionCode)
+	}
+	if header.Pcn != "PCN1234567" {
+		t.Errorf("Pcn mismatch. Wanted: PCN1234567   Got: %q", header.Pcn)
+	}
+	if header.RecordCount != 1 {
+		t.Errorf("RecordCount mismatch. Wanted: 1   Got: %v", header.RecordCount)
+	}
+	if header.ServiceProviderIdQualifier != "01" {
+		t.Errorf("ServiceProviderIdQualifier mismatch. Wanted: 01   Got: %q", header.ServiceProviderIdQualifier)
+	}
+	if header.ServiceProviderId != "1234567893" {
+		t.Errorf("ServiceProviderId mismatch. Wanted: 1234567893   Got: %q", header.ServiceProviderId)
+	}
+	if header.DateOfService != "20260611" {
+		t.Errorf("DateOfService mismatch. Wanted: 20260611   Got: %q", header.DateOfService)
+	}
+	if header.SoftwareVendorCertificationId != "VENDORCERT" {
+		t.Errorf("SoftwareVendorCertificationId mismatch. Wanted: VENDORCERT   Got: %q", header.SoftwareVendorCertificationId)
+	}
+	if obj.Header.Size != 58 {
+		t.Errorf("Header size mismatch. Wanted: 58   Got: %v", obj.Header.Size)
+	}
+
+	insurance := obj.Insurance
+	assertString(t, "Insurance cardholder id (C2)", insurance.Cardholder.Id, "CARDID")
+	assertString(t, "Insurance cardholder first name (CC)", insurance.Cardholder.FirstName, "CARDFIRST")
+	assertString(t, "Insurance cardholder last name (CD)", insurance.Cardholder.LastName, "CARDLAST")
+	assertString(t, "Insurance plan id (FO)", insurance.PlanId, "PLANID")
+	assertString(t, "Insurance eligibility clarification code (C9)", insurance.EligbilityClarificationCode, "0")
+	assertString(t, "Insurance group id (C1)", insurance.GroupId, "D0PAID")
+	assertString(t, "Insurance person code (C3)", insurance.PersonCode, "001")
+	assertString(t, "Insurance patient relationship code (C6)", insurance.PatientRelationshipCode, "1")
+	assertString(t, "Insurance medigap id (2A)", insurance.MedigapId, "MEDIGAPID")
+	assertString(t, "Insurance medicaid indicator (2B)", insurance.Medicaid.Indicator, "SC")
+	assertString(t, "Insurance provider accept assignment (2D)", insurance.ProviderAcceptAssignment, "N")
+	assertString(t, "Insurance medicaid id (N5)", insurance.Medicaid.Id, "MEDICAIDIDNUMBER")
+	if len(insurance.DynamicFields) != 0 {
+		t.Errorf("Insurance dynamic field spillover. Wanted: 0   Got: %v", len(insurance.DynamicFields))
+	}
+
+	patient := obj.Patient
+	if patient.IdCount == nil || *patient.IdCount != 1 {
+		t.Errorf("Patient id count (RR) mismatch. Wanted: 1   Got: %v", patient.IdCount)
+	}
+	assertString(t, "Patient id qualifier (CX)", patient.IdQualifier, "99")
+	assertString(t, "Patient id (CY)", patient.Id, "PATIENTID")
+	if len(patient.Ids) != 1 {
+		t.Errorf("Patient Ids count mismatch. Wanted: 1   Got: %v", len(patient.Ids))
+	} else {
+		assertString(t, "Patient Ids[0] qualifier", patient.Ids[0].Qualifier, "99")
+		assertString(t, "Patient Ids[0] id", patient.Ids[0].Id, "PATIENTID")
+	}
+	if patient.BirthDate == nil || patient.BirthDate.Format("20060102") != "19850601" {
+		t.Errorf("Patient birth date (C4) mismatch. Wanted: 19850601   Got: %v", patient.BirthDate)
+	}
+	assertString(t, "Patient gender code (C5)", patient.GenderCode, "1")
+	assertString(t, "Patient first name (CA)", patient.FirstName, "FIRSTNAME")
+	assertString(t, "Patient last name (CB)", patient.LastName, "LASTNAME")
+	assertString(t, "Patient address street line 1 (F6 field 7A)", patient.Address.StreetLine1, "1234 FIRST ADDRESS LINE")
+	assertString(t, "Patient address street line 2 (F6 field 7B)", patient.Address.StreetLine2, "7890 SECOND ADDRESS LINE")
+	assertString(t, "Patient address city (CN)", patient.Address.City, "ROEBUCK")
+	assertString(t, "Patient address state (CO)", patient.Address.State, "SC")
+	assertString(t, "Patient address zip (CP)", patient.Address.Zip, "293764444")
+	assertString(t, "Patient address country code (F6 field 1K)", patient.Address.CountryCode, "US")
+	assertString(t, "Patient phone (CQ)", patient.Phone, "8645555555")
+	assertString(t, "Patient place of service (C7)", patient.PlaceOfService, "01")
+	assertString(t, "Patient employer id (CZ)", patient.EmployerId, "EMPLOYERID")
+	assertString(t, "Patient pregnant (2C)", patient.Pregnant, "1")
+	assertString(t, "Patient email (HN)", patient.Email, "EMAIL@DOMAIN.COM")
+	assertString(t, "Patient residence (4X)", patient.Residence, "1")
+	assertString(t, "Patient species (F6 field S8)", patient.Species, "337915000")
+	if len(patient.DynamicFields) != 0 {
+		t.Errorf("Patient dynamic field spillover. Wanted: 0   Got: %v", len(patient.DynamicFields))
+	}
+
+	if len(obj.Claims) != 1 {
+		t.Fatalf("Group count mismatch. Wanted: 1   Got: %v", len(obj.Claims))
+	}
+
+	pricing := obj.Claims[0].Pricing
+	assertFloat(t, "Pricing ingredient cost (D9)", pricing.IngredientCostSubmitted, 123456.78)
+	assertFloat(t, "Pricing dispensing fee (DC)", pricing.DispensingFeeSubmitted, 25.00)
+	assertFloat(t, "Pricing professional service fee (BE)", pricing.ProfessionalServiceFeeSubmitted, 20.00)
+	// DX is present but empty in the raw sample; the deserializer allocates the
+	// pointer and leaves the zero value.
+	assertFloat(t, "Pricing patient paid amount (DX, empty)", pricing.PatientPaidAmountSubmitted, 0)
+	assertFloat(t, "Pricing incentive amount (E3)", pricing.IncentiveAmountSubmitted, 5.00)
+	if pricing.OtherAmountClaimSubmittedCount == nil || *pricing.OtherAmountClaimSubmittedCount != 1 {
+		t.Errorf("Pricing other amount count (H7) mismatch. Wanted: 1   Got: %v", pricing.OtherAmountClaimSubmittedCount)
+	}
+	if len(pricing.OtherAmountClaimSubmitted) != 1 {
+		t.Errorf("Pricing other amounts count mismatch. Wanted: 1   Got: %v", len(pricing.OtherAmountClaimSubmitted))
+	} else {
+		assertString(t, "Pricing other amount qualifier (H8)", pricing.OtherAmountClaimSubmitted[0].Qualifier, "01")
+		assertFloat(t, "Pricing other amount (H9)", pricing.OtherAmountClaimSubmitted[0].AmountSubmitted, 7.55)
+	}
+	if pricing.RegulatoryFeeCount == nil || *pricing.RegulatoryFeeCount != 1 {
+		t.Errorf("Pricing regulatory fee count (F6 field RK) mismatch. Wanted: 1   Got: %v", pricing.RegulatoryFeeCount)
+	}
+	if len(pricing.RegulatoryFees) != 1 {
+		t.Errorf("Pricing regulatory fees count mismatch. Wanted: 1   Got: %v", len(pricing.RegulatoryFees))
+	} else {
+		assertString(t, "Pricing regulatory fee type (F6 field RL)", pricing.RegulatoryFees[0].TypeCode, "AB")
+	}
+	assertFloat(t, "Pricing flat sales tax (HA)", pricing.FlatSalesTaxAmountSubmitted, 4.32)
+	assertFloat(t, "Pricing percentage sales tax amount (GE)", pricing.PercentageSalesTaxAmountSubmitted, 1234.57)
+	assertFloat(t, "Pricing percentage sales tax rate (HE)", pricing.PercentageSalesTaxRateSubmitted, 1.0000)
+	assertString(t, "Pricing percentage sales tax basis (JE)", pricing.PercentageSalesTaxBasisSubmitted, "02")
+	assertFloat(t, "Pricing usual and customary charge (DQ)", pricing.UsualAndCustmaryCharge, 134567.00)
+	assertFloat(t, "Pricing gross amount due (DU)", pricing.GrossAmountDue, 124753.22)
+	assertString(t, "Pricing basis of cost determination (DN)", pricing.BasisOfCostDetermination, "01")
+	if len(pricing.DynamicFields) != 0 {
+		t.Errorf("Pricing dynamic field spillover. Wanted: 0   Got: %v", len(pricing.DynamicFields))
+	}
+}
+
+// An F6 transmission with only shared segments must parse without error and
+// without inventing a claim group.
+func Test_CanParseF6RequestWithoutTransactionSegments(t *testing.T) {
+	fs := string(ncpdp.FIELD)
+	ss := string(ncpdp.SEGMENT)
+
+	rawData := F6_REQUEST_B1_HEADER +
+		ss + fs + "AM04" + fs + "C2POLICY123" + fs + "C61" +
+		ss + fs + "AM01" + fs + "CX99" + fs + "CYPATIENTID" + fs + "CAJOHN" + fs + "CBDOE"
+
+	obj := request.Billing{}
+	err := DeserializeType(rawData, &obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if obj.Insurance.Cardholder.Id == nil || *obj.Insurance.Cardholder.Id != "POLICY123" {
+		t.Errorf("Insurance cardholder id mismatch. Wanted: POLICY123   Got: %v", obj.Insurance.Cardholder.Id)
+	}
+	if obj.Patient.LastName == nil || *obj.Patient.LastName != "DOE" {
+		t.Errorf("Patient last name mismatch. Wanted: DOE   Got: %v", obj.Patient.LastName)
+	}
+	if len(obj.Claims) != 0 {
+		t.Errorf("Group count mismatch. Wanted: 0   Got: %v", len(obj.Claims))
+	}
+}
+
+// Without group separators the claim group starts at the first segment whose
+// ID belongs to the group struct. Unknown segments before that boundary stay
+// in the shared DynamicSegments; unknown segments after it belong to the claim.
+func Test_F6UnknownSegmentsRespectGroupBoundary(t *testing.T) {
+	fs := string(ncpdp.FIELD)
+	ss := string(ncpdp.SEGMENT)
+
+	rawData := F6_REQUEST_B1_HEADER +
+		ss + fs + "AM04" + fs + "C2POLICY123" + fs + "C61" +
+		ss + fs + "AM98" + fs + "A11" + fs + "A2BB" +
+		ss + fs + "AM07" + fs + "EM1" + fs + "D26000001" +
+		ss + fs + "AM99" + fs + "B3CC" + fs + "B41"
+
+	obj := request.Billing{}
+	err := DeserializeType(rawData, &obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(obj.DynamicSegments) != 1 {
+		t.Errorf("Shared dynamic segment count mismatch. Wanted: 1 (AM98)   Got: %v", len(obj.DynamicSegments))
+	}
+
+	if len(obj.Claims) != 1 {
+		t.Fatalf("Group count mismatch. Wanted: 1   Got: %v", len(obj.Claims))
+	}
+
+	claim := obj.Claims[0]
+	rxNumber := claim.Claim.PrescriptionServiceReference.Number
+	if rxNumber == nil || *rxNumber != "6000001" {
+		t.Errorf("Prescription number (D2) mismatch. Wanted: 6000001   Got: %v", rxNumber)
+	}
+	if len(claim.DynamicSegments) != 1 {
+		t.Errorf("Claim dynamic segment count mismatch. Wanted: 1 (AM99)   Got: %v", len(claim.DynamicSegments))
 	}
 }

--- a/pkg/claimDeserializer/concurrency_test.go
+++ b/pkg/claimDeserializer/concurrency_test.go
@@ -23,38 +23,60 @@ func Test_DeserializeIsConcurrencySafe(t *testing.T) {
 			defer wg.Done()
 
 			for i := 0; i < iterations; i++ {
-				obj := request.Billing{}
-				if err := DeserializeType(REQUEST_B1, &obj); err != nil {
-					t.Errorf("Failed to deserialize B1: %v", err)
+				if !deserializeB1Concurrently(t) || !deserializeF6Concurrently(t, rawF6) {
 					return
 				}
-				assertString(t, "Cardholder id under concurrency", obj.Insurance.Cardholder.Id, "POLICYNUMBERTHATISLO")
-				if len(obj.Claims) != 1 {
-					t.Errorf("Group count mismatch under concurrency. Wanted: 1   Got: %v", len(obj.Claims))
-					return
-				}
-
-				res, err := Deserialize(rawF6)
-				if err != nil {
-					t.Errorf("Failed to deserialize F6: %v", err)
-					return
-				}
-				f6, ok := res.(request.Billing)
-				if !ok {
-					t.Errorf("Expected request.Billing, got: %T", res)
-					return
-				}
-				assertF6FullSampleHeader(t, f6)
-				assertF6FullSampleInsurance(t, f6)
-				assertF6FullSamplePatient(t, f6)
-				if len(f6.Claims) != 1 {
-					t.Errorf("F6 group count mismatch under concurrency. Wanted: 1   Got: %v", len(f6.Claims))
-					return
-				}
-				assertF6FullSamplePricing(t, f6)
 			}
 		}()
 	}
 
 	wg.Wait()
+}
+
+func deserializeB1Concurrently(t *testing.T) bool {
+	t.Helper()
+
+	obj := request.Billing{}
+	if err := DeserializeType(REQUEST_B1, &obj); err != nil {
+		t.Errorf("Failed to deserialize B1: %v", err)
+		return false
+	}
+
+	assertString(t, "Cardholder id under concurrency", obj.Insurance.Cardholder.Id, "POLICYNUMBERTHATISLO")
+
+	if len(obj.Claims) != 1 {
+		t.Errorf("Group count mismatch under concurrency. Wanted: 1   Got: %v", len(obj.Claims))
+		return false
+	}
+
+	return true
+}
+
+func deserializeF6Concurrently(t *testing.T, rawF6 string) bool {
+	t.Helper()
+
+	res, err := Deserialize(rawF6)
+	if err != nil {
+		t.Errorf("Failed to deserialize F6: %v", err)
+		return false
+	}
+
+	f6, ok := res.(request.Billing)
+	if !ok {
+		t.Errorf("Expected request.Billing, got: %T", res)
+		return false
+	}
+
+	assertF6FullSampleHeader(t, f6)
+	assertF6FullSampleInsurance(t, f6)
+	assertF6FullSamplePatient(t, f6)
+
+	if len(f6.Claims) != 1 {
+		t.Errorf("F6 group count mismatch under concurrency. Wanted: 1   Got: %v", len(f6.Claims))
+		return false
+	}
+
+	assertF6FullSamplePricing(t, f6)
+
+	return true
 }

--- a/pkg/claimDeserializer/concurrency_test.go
+++ b/pkg/claimDeserializer/concurrency_test.go
@@ -1,0 +1,60 @@
+package claimdeserializer
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp/request"
+)
+
+// The serde attribute/definition caches are shared across goroutines, so
+// deserialization must be safe and deterministic under concurrent use.
+// Run with -race to catch data races.
+func Test_DeserializeIsConcurrencySafe(t *testing.T) {
+	rawF6 := buildF6FullBillingRequest()
+
+	const goroutines = 10
+	const iterations = 25
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for i := 0; i < iterations; i++ {
+				obj := request.Billing{}
+				if err := DeserializeType(REQUEST_B1, &obj); err != nil {
+					t.Errorf("Failed to deserialize B1: %v", err)
+					return
+				}
+				assertString(t, "Cardholder id under concurrency", obj.Insurance.Cardholder.Id, "POLICYNUMBERTHATISLO")
+				if len(obj.Claims) != 1 {
+					t.Errorf("Group count mismatch under concurrency. Wanted: 1   Got: %v", len(obj.Claims))
+					return
+				}
+
+				res, err := Deserialize(rawF6)
+				if err != nil {
+					t.Errorf("Failed to deserialize F6: %v", err)
+					return
+				}
+				f6, ok := res.(request.Billing)
+				if !ok {
+					t.Errorf("Expected request.Billing, got: %T", res)
+					return
+				}
+				assertF6FullSampleHeader(t, f6)
+				assertF6FullSampleInsurance(t, f6)
+				assertF6FullSamplePatient(t, f6)
+				if len(f6.Claims) != 1 {
+					t.Errorf("F6 group count mismatch under concurrency. Wanted: 1   Got: %v", len(f6.Claims))
+					return
+				}
+				assertF6FullSamplePricing(t, f6)
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/pkg/claimSerializer/bench_test.go
+++ b/pkg/claimSerializer/bench_test.go
@@ -1,0 +1,38 @@
+package claimserializer
+
+import (
+	"testing"
+
+	claimdeserializer "github.com/transactrx/NCPDPSerDe/pkg/claimDeserializer"
+	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp/request"
+)
+
+func Benchmark_SerializeB1(b *testing.B) {
+	obj := request.Billing{}
+	if err := claimdeserializer.DeserializeType(REQUEST_B1, &obj); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := Serialize(&obj)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func Benchmark_SerializeF6(b *testing.B) {
+	obj := request.Billing{}
+	if err := claimdeserializer.DeserializeType(buildF6BillingRequest(), &obj); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := Serialize(&obj)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/claimSerializer/claimSerializer.go
+++ b/pkg/claimSerializer/claimSerializer.go
@@ -326,76 +326,104 @@ func collectFieldCodes(structType reflect.Type, codes map[string]bool) {
 }
 
 func buildStructField(ft reflect.Type, fieldVal reflect.Value, fieldAttribute *serde.FieldAttribute, skipCodes map[string]bool) (map[int]string, error) {
-	rawFieldMap := make(map[int]string)
-
 	switch ft.Kind() {
 	case reflect.Struct:
 		return buildFieldMap(ft, fieldVal, skipCodes)
 
 	case reflect.Pointer:
-		if fieldAttribute != nil && fieldAttribute.Order > 0 {
-			if !fieldVal.IsNil() && !skipCodes[fieldAttribute.Code] {
-				rawField, err := buildField(*fieldAttribute, fieldVal.Elem())
-				if err != nil {
-					return rawFieldMap, err
-				}
-
-				rawFieldMap[fieldAttribute.Order] = rawField
-			}
-
-			break
-		}
-
-		return buildStructField(ft.Elem(), fieldVal.Elem(), fieldAttribute, skipCodes)
+		return buildPointerField(ft, fieldVal, fieldAttribute, skipCodes)
 
 	case reflect.Slice, reflect.Array:
-		builder := strings.Builder{}
-		order := math.MaxInt
-
-		for i := 0; i < fieldVal.Len(); i++ {
-			element := fieldVal.Index(i)
-
-			fm, err := buildFieldMap(element.Type(), element, nil)
-			if err != nil {
-				return rawFieldMap, err
-			}
-
-			// Get keys and sort
-			fmKeys := make([]int, 0, len(fm))
-			for k := range fm {
-				fmKeys = append(fmKeys, k)
-			}
-
-			slices.Sort(fmKeys)
-
-			// Concat all fields for element
-			for _, fmOrder := range fmKeys {
-				fmVal, ok := fm[fmOrder]
-				if ok {
-					builder.WriteString(fmVal)
-
-					if fmOrder < order {
-						order = fmOrder
-					}
-				}
-			}
-		}
-
-		rawString := builder.String()
-		if rawString != serde.Empty {
-			rawFieldMap[order] = rawString
-		}
+		return buildSliceField(fieldVal)
 
 	default:
-		if fieldAttribute != nil && fieldAttribute.Order > 0 && !skipCodes[fieldAttribute.Code] {
-			rawField, err := buildField(*fieldAttribute, fieldVal)
-			if err != nil {
-				return rawFieldMap, err
-			}
+		return buildScalarField(fieldVal, fieldAttribute, skipCodes)
+	}
+}
 
-			rawFieldMap[fieldAttribute.Order] = rawField
+func buildPointerField(ft reflect.Type, fieldVal reflect.Value, fieldAttribute *serde.FieldAttribute, skipCodes map[string]bool) (map[int]string, error) {
+	if fieldAttribute == nil || fieldAttribute.Order <= 0 {
+		return buildStructField(ft.Elem(), fieldVal.Elem(), fieldAttribute, skipCodes)
+	}
+
+	rawFieldMap := make(map[int]string)
+
+	if fieldVal.IsNil() || skipCodes[fieldAttribute.Code] {
+		return rawFieldMap, nil
+	}
+
+	rawField, err := buildField(*fieldAttribute, fieldVal.Elem())
+	if err != nil {
+		return rawFieldMap, err
+	}
+
+	rawFieldMap[fieldAttribute.Order] = rawField
+
+	return rawFieldMap, nil
+}
+
+func buildSliceField(fieldVal reflect.Value) (map[int]string, error) {
+	rawFieldMap := make(map[int]string)
+
+	builder := strings.Builder{}
+	order := math.MaxInt
+
+	for i := 0; i < fieldVal.Len(); i++ {
+		element := fieldVal.Index(i)
+
+		fm, err := buildFieldMap(element.Type(), element, nil)
+		if err != nil {
+			return rawFieldMap, err
+		}
+
+		elementOrder := writeSortedFieldMap(&builder, fm)
+		if elementOrder < order {
+			order = elementOrder
 		}
 	}
+
+	rawString := builder.String()
+	if rawString != serde.Empty {
+		rawFieldMap[order] = rawString
+	}
+
+	return rawFieldMap, nil
+}
+
+// writeSortedFieldMap appends the map values to the builder in order and
+// returns the lowest order present (math.MaxInt when the map is empty).
+func writeSortedFieldMap(builder *strings.Builder, fm map[int]string) int {
+	fmKeys := make([]int, 0, len(fm))
+	for k := range fm {
+		fmKeys = append(fmKeys, k)
+	}
+
+	slices.Sort(fmKeys)
+
+	for _, fmOrder := range fmKeys {
+		builder.WriteString(fm[fmOrder])
+	}
+
+	if len(fmKeys) == 0 {
+		return math.MaxInt
+	}
+
+	return fmKeys[0]
+}
+
+func buildScalarField(fieldVal reflect.Value, fieldAttribute *serde.FieldAttribute, skipCodes map[string]bool) (map[int]string, error) {
+	rawFieldMap := make(map[int]string)
+
+	if fieldAttribute == nil || fieldAttribute.Order <= 0 || skipCodes[fieldAttribute.Code] {
+		return rawFieldMap, nil
+	}
+
+	rawField, err := buildField(*fieldAttribute, fieldVal)
+	if err != nil {
+		return rawFieldMap, err
+	}
+
+	rawFieldMap[fieldAttribute.Order] = rawField
 
 	return rawFieldMap, nil
 }

--- a/pkg/claimSerializer/claimSerializer.go
+++ b/pkg/claimSerializer/claimSerializer.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/transactrx/NCPDPSerDe/pkg/dynamic"
@@ -286,7 +287,9 @@ func mergeSliceFieldCodes(baseType reflect.Type, baseVal reflect.Value, skipCode
 			}
 		}
 
-		collectFieldCodes(field.Type.Elem(), merged)
+		for code := range fieldCodesForType(field.Type.Elem()) {
+			merged[code] = true
+		}
 	}
 
 	if merged == nil {
@@ -294,6 +297,26 @@ func mergeSliceFieldCodes(baseType reflect.Type, baseVal reflect.Value, skipCode
 	}
 
 	return merged
+}
+
+var fieldCodesCache sync.Map
+
+// Cached set of field tag codes for a struct type. The returned map must not be modified.
+func fieldCodesForType(structType reflect.Type) map[string]bool {
+	structType = reflectionutils.GetElementType(structType)
+	if structType.Kind() != reflect.Struct {
+		return nil
+	}
+
+	if cached, ok := fieldCodesCache.Load(structType); ok {
+		return cached.(map[string]bool)
+	}
+
+	codes := map[string]bool{}
+	collectFieldCodes(structType, codes)
+	fieldCodesCache.Store(structType, codes)
+
+	return codes
 }
 
 // Collect all field tag codes defined on a struct type, recursing into nested structs.

--- a/pkg/claimSerializer/claimSerializer.go
+++ b/pkg/claimSerializer/claimSerializer.go
@@ -40,8 +40,11 @@ func Serialize[V any](claim *V) (string, error) {
 	}
 	builder.WriteString(rawSegs)
 
-	// Build groups
-	rawGrps, err := buildGroups(claimType, claimObjectRef)
+	// Build groups. vEB+ versions (e.g. F6) eliminated the group separator and
+	// allow only a single transaction per transmission.
+	omitGroupSeparators := strings.HasPrefix(rawHdr, "F")
+
+	rawGrps, err := buildGroups(claimType, claimObjectRef, omitGroupSeparators)
 	if err != nil {
 		return serde.Empty, err
 	}
@@ -85,7 +88,7 @@ func buildHeader(structType reflect.Type, structVal reflect.Value) (string, erro
 }
 
 // Build raw groups.
-func buildGroups(structType reflect.Type, structVal reflect.Value) (string, error) {
+func buildGroups(structType reflect.Type, structVal reflect.Value, omitGroupSeparators bool) (string, error) {
 	baseType := reflectionutils.GetElementType(structType)
 	baseVal := reflectionutils.GetElementValue(structVal)
 
@@ -101,6 +104,10 @@ func buildGroups(structType reflect.Type, structVal reflect.Value) (string, erro
 
 	groupSlice := baseVal.FieldByName(groupField.Name)
 
+	if omitGroupSeparators && groupSlice.Len() > 1 {
+		return serde.Empty, fmt.Errorf("NCPDP versions without group separators (vEB and higher) allow a single transaction per transmission; found %d claim groups", groupSlice.Len())
+	}
+
 	builder := strings.Builder{}
 
 	for i := 0; i < groupSlice.Len(); i++ {
@@ -111,7 +118,9 @@ func buildGroups(structType reflect.Type, structVal reflect.Value) (string, erro
 			return serde.Empty, err
 		}
 
-		builder.WriteByte(ncpdp.GROUP)
+		if !omitGroupSeparators {
+			builder.WriteByte(ncpdp.GROUP)
+		}
 		builder.WriteString(rawSegs)
 	}
 
@@ -183,7 +192,7 @@ func buildSegment(structType reflect.Type, structVal reflect.Value) (string, err
 	builder.WriteByte(ncpdp.SEGMENT)
 
 	// Build map of fields and contents
-	rawFieldMap, err := buildFieldMap(baseType, baseVal)
+	rawFieldMap, err := buildFieldMap(baseType, baseVal, nil)
 	if err != nil {
 		return builder.String(), err
 	}
@@ -213,7 +222,7 @@ func buildSegment(structType reflect.Type, structVal reflect.Value) (string, err
 	return rawSegment, nil
 }
 
-func buildFieldMap(structType reflect.Type, structVal reflect.Value) (map[int]string, error) {
+func buildFieldMap(structType reflect.Type, structVal reflect.Value, skipCodes map[string]bool) (map[int]string, error) {
 	baseType := reflectionutils.GetElementType(structType)
 	baseVal := reflectionutils.GetElementValue(structVal)
 
@@ -223,6 +232,11 @@ func buildFieldMap(structType reflect.Type, structVal reflect.Value) (map[int]st
 		baseType = reflectionutils.GetElementType(ds.DynamicType)
 		baseVal = reflectionutils.GetElementValue(reflect.ValueOf(ds.Value))
 	}
+
+	// Codes already emitted by populated repeating slices suppress their scalar
+	// counterparts so dual-mapped fields (D0 scalar + F6 repeating slice) are
+	// not serialized twice.
+	skipCodes = mergeSliceFieldCodes(baseType, baseVal, skipCodes)
 
 	rawFieldMap := make(map[int]string)
 
@@ -236,7 +250,7 @@ func buildFieldMap(structType reflect.Type, structVal reflect.Value) (map[int]st
 			return rawFieldMap, err
 		}
 
-		fieldResult, err := buildStructField(field.Type, fieldVal, &fieldAttribute)
+		fieldResult, err := buildStructField(field.Type, fieldVal, &fieldAttribute, skipCodes)
 		if err != nil {
 			return rawFieldMap, err
 		}
@@ -249,16 +263,78 @@ func buildFieldMap(structType reflect.Type, structVal reflect.Value) (map[int]st
 	return rawFieldMap, nil
 }
 
-func buildStructField(ft reflect.Type, fieldVal reflect.Value, fieldAttribute *serde.FieldAttribute) (map[int]string, error) {
+// Union of skipCodes and the field codes contained in non-empty slice fields.
+func mergeSliceFieldCodes(baseType reflect.Type, baseVal reflect.Value, skipCodes map[string]bool) map[string]bool {
+	var merged map[string]bool
+
+	for i := 0; i < baseType.NumField(); i++ {
+		field := baseType.Field(i)
+
+		if field.Type.Kind() != reflect.Slice {
+			continue
+		}
+
+		fieldVal := baseVal.FieldByName(field.Name)
+		if !fieldVal.IsValid() || fieldVal.Len() == 0 {
+			continue
+		}
+
+		if merged == nil {
+			merged = make(map[string]bool, len(skipCodes))
+			for k := range skipCodes {
+				merged[k] = true
+			}
+		}
+
+		collectFieldCodes(field.Type.Elem(), merged)
+	}
+
+	if merged == nil {
+		return skipCodes
+	}
+
+	return merged
+}
+
+// Collect all field tag codes defined on a struct type, recursing into nested structs.
+func collectFieldCodes(structType reflect.Type, codes map[string]bool) {
+	structType = reflectionutils.GetElementType(structType)
+	if structType.Kind() != reflect.Struct {
+		return
+	}
+
+	for i := 0; i < structType.NumField(); i++ {
+		field := structType.Field(i)
+
+		tag := field.Tag.Get(serde.FieldTag)
+		if tag != serde.Empty {
+			attr, err := serde.GetFieldAttribute(tag)
+			if err == nil && attr.Code != serde.Empty {
+				codes[attr.Code] = true
+			}
+		}
+
+		switch field.Type.Kind() {
+		case reflect.Struct:
+			collectFieldCodes(field.Type, codes)
+		case reflect.Pointer:
+			if field.Type.Elem().Kind() == reflect.Struct {
+				collectFieldCodes(field.Type.Elem(), codes)
+			}
+		}
+	}
+}
+
+func buildStructField(ft reflect.Type, fieldVal reflect.Value, fieldAttribute *serde.FieldAttribute, skipCodes map[string]bool) (map[int]string, error) {
 	rawFieldMap := make(map[int]string)
 
 	switch ft.Kind() {
 	case reflect.Struct:
-		return buildFieldMap(ft, fieldVal)
+		return buildFieldMap(ft, fieldVal, skipCodes)
 
 	case reflect.Pointer:
 		if fieldAttribute != nil && fieldAttribute.Order > 0 {
-			if !fieldVal.IsNil() {
+			if !fieldVal.IsNil() && !skipCodes[fieldAttribute.Code] {
 				rawField, err := buildField(*fieldAttribute, fieldVal.Elem())
 				if err != nil {
 					return rawFieldMap, err
@@ -270,7 +346,7 @@ func buildStructField(ft reflect.Type, fieldVal reflect.Value, fieldAttribute *s
 			break
 		}
 
-		return buildStructField(ft.Elem(), fieldVal.Elem(), fieldAttribute)
+		return buildStructField(ft.Elem(), fieldVal.Elem(), fieldAttribute, skipCodes)
 
 	case reflect.Slice, reflect.Array:
 		builder := strings.Builder{}
@@ -279,7 +355,7 @@ func buildStructField(ft reflect.Type, fieldVal reflect.Value, fieldAttribute *s
 		for i := 0; i < fieldVal.Len(); i++ {
 			element := fieldVal.Index(i)
 
-			fm, err := buildFieldMap(element.Type(), element)
+			fm, err := buildFieldMap(element.Type(), element, nil)
 			if err != nil {
 				return rawFieldMap, err
 			}
@@ -311,7 +387,7 @@ func buildStructField(ft reflect.Type, fieldVal reflect.Value, fieldAttribute *s
 		}
 
 	default:
-		if fieldAttribute != nil && fieldAttribute.Order > 0 {
+		if fieldAttribute != nil && fieldAttribute.Order > 0 && !skipCodes[fieldAttribute.Code] {
 			rawField, err := buildField(*fieldAttribute, fieldVal)
 			if err != nil {
 				return rawFieldMap, err

--- a/pkg/claimSerializer/claimSerializer_test.go
+++ b/pkg/claimSerializer/claimSerializer_test.go
@@ -267,6 +267,47 @@ func buildF6BillingResponse() string {
 		ss + fs + "AM22" + fs + "EM1" + fs + "D26000001"
 }
 
+func assertString(t *testing.T, name string, got *string, want string) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("%s mismatch. Wanted: %q   Got: nil", name, want)
+	} else if *got != want {
+		t.Errorf("%s mismatch. Wanted: %q   Got: %q", name, want, *got)
+	}
+}
+
+func assertInt(t *testing.T, name string, got *int, want int) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("%s mismatch. Wanted: %v   Got: nil", name, want)
+	} else if *got != want {
+		t.Errorf("%s mismatch. Wanted: %v   Got: %v", name, want, *got)
+	}
+}
+
+// assertFieldCount verifies how many times a field code is emitted in the
+// serialized transmission.
+func assertFieldCount(t *testing.T, serialized, code string, want int) {
+	t.Helper()
+	if got := strings.Count(serialized, string(ncpdp.FIELD)+code); got != want {
+		t.Errorf("Serialized %s occurrence mismatch. Wanted: %v   Got: %v", code, want, got)
+	}
+}
+
+func assertNoGroupSeparators(t *testing.T, serialized string) {
+	t.Helper()
+	if got := strings.Count(serialized, string(ncpdp.GROUP)); got != 0 {
+		t.Errorf("F6 transmissions must not contain group separators. Found: %v", got)
+	}
+}
+
+func assertHeaderPrefix(t *testing.T, serialized, wantHeader string) {
+	t.Helper()
+	if len(serialized) < len(wantHeader) || serialized[:len(wantHeader)] != wantHeader {
+		t.Errorf("Serialized F6 header mismatch.\nWanted prefix: %q\nGot:           %q", wantHeader, serialized[:min(len(serialized), len(wantHeader))])
+	}
+}
+
 func Test_CanRoundTripF6BillingRequest(t *testing.T) {
 	obj := request.Billing{}
 	err := claimdeserializer.DeserializeType(buildF6BillingRequest(), &obj)
@@ -279,9 +320,13 @@ func Test_CanRoundTripF6BillingRequest(t *testing.T) {
 		t.Fatalf("Failed to serialize: %v", err)
 	}
 
-	if len(serialized) < 58 || serialized[:58] != F6_REQUEST_B1_HEADER {
-		t.Errorf("Serialized F6 header mismatch.\nWanted prefix: %q\nGot:           %q", F6_REQUEST_B1_HEADER, serialized[:min(len(serialized), 58)])
-	}
+	assertHeaderPrefix(t, serialized, F6_REQUEST_B1_HEADER)
+	assertNoGroupSeparators(t, serialized)
+
+	// Repeating patient ID: the Ids slice must survive the round trip and the
+	// scalar Id/IdQualifier must not cause duplicate CX/CY field emission.
+	assertFieldCount(t, serialized, "CX", 2)
+	assertFieldCount(t, serialized, "CY", 2)
 
 	// Re-deserialize and verify the F6 fields survive the round trip
 	obj2 := request.Billing{}
@@ -293,23 +338,8 @@ func Test_CanRoundTripF6BillingRequest(t *testing.T) {
 	if obj2.Header.Value != obj.Header.Value {
 		t.Errorf("Header mismatch after round trip.\nWanted: %+v\nGot:    %+v", obj.Header.Value, obj2.Header.Value)
 	}
-	if obj2.Patient.MiddleName == nil || *obj2.Patient.MiddleName != "QUINCY" {
-		t.Errorf("Patient middle name (F6 field 0C) mismatch after round trip. Wanted: QUINCY   Got: %v", obj2.Patient.MiddleName)
-	}
+	assertString(t, "Patient middle name (F6 field 0C) after round trip", obj2.Patient.MiddleName, "QUINCY")
 
-	if got := strings.Count(serialized, string(ncpdp.GROUP)); got != 0 {
-		t.Errorf("F6 transmissions must not contain group separators. Found: %v", got)
-	}
-
-	// Repeating patient ID: the Ids slice must survive the round trip and the
-	// scalar Id/IdQualifier must not cause duplicate CX/CY field emission.
-	fs := string(ncpdp.FIELD)
-	if got := strings.Count(serialized, fs+"CX"); got != 2 {
-		t.Errorf("Serialized CX occurrence mismatch. Wanted: 2   Got: %v", got)
-	}
-	if got := strings.Count(serialized, fs+"CY"); got != 2 {
-		t.Errorf("Serialized CY occurrence mismatch. Wanted: 2   Got: %v", got)
-	}
 	if len(obj2.Patient.Ids) != 2 {
 		t.Errorf("Patient ids count mismatch after round trip. Wanted: 2   Got: %v", len(obj2.Patient.Ids))
 	}
@@ -317,9 +347,7 @@ func Test_CanRoundTripF6BillingRequest(t *testing.T) {
 		t.Fatalf("Group count mismatch after round trip. Wanted: 1   Got: %v", len(obj2.Claims))
 	}
 	intermediary := obj2.Claims[0].Intermediary
-	if intermediary.IdCount == nil || *intermediary.IdCount != 1 {
-		t.Errorf("Intermediary id count (F6 field 8G) mismatch after round trip. Wanted: 1   Got: %v", intermediary.IdCount)
-	}
+	assertInt(t, "Intermediary id count (F6 field 8G) after round trip", intermediary.IdCount, 1)
 	if len(intermediary.Ids) != 1 || intermediary.Ids[0].Id == nil || *intermediary.Ids[0].Id != "INTERMEDIARY01" {
 		t.Errorf("Intermediary ids (F6 segment AM19) mismatch after round trip. Got: %+v", intermediary.Ids)
 	}
@@ -395,25 +423,13 @@ func Test_CanRoundTripF6FullFieldSample(t *testing.T) {
 		t.Fatalf("Failed to serialize: %v", err)
 	}
 
-	if len(serialized) < 58 || serialized[:58] != F6_REQUEST_FULL_HEADER {
-		t.Errorf("Serialized F6 header mismatch.\nWanted prefix: %q\nGot:           %q", F6_REQUEST_FULL_HEADER, serialized[:min(len(serialized), 58)])
-	}
-
-	if got := strings.Count(serialized, string(ncpdp.GROUP)); got != 0 {
-		t.Errorf("F6 transmissions must not contain group separators. Found: %v", got)
-	}
+	assertHeaderPrefix(t, serialized, F6_REQUEST_FULL_HEADER)
+	assertNoGroupSeparators(t, serialized)
 
 	// Single-occurrence dual-mapped patient ID must serialize exactly once.
-	fs := string(ncpdp.FIELD)
-	if got := strings.Count(serialized, fs+"CX"); got != 1 {
-		t.Errorf("Serialized CX occurrence mismatch. Wanted: 1   Got: %v", got)
-	}
-	if got := strings.Count(serialized, fs+"CY"); got != 1 {
-		t.Errorf("Serialized CY occurrence mismatch. Wanted: 1   Got: %v", got)
-	}
-	if got := strings.Count(serialized, fs+"RL"); got != 1 {
-		t.Errorf("Serialized RL occurrence mismatch. Wanted: 1   Got: %v", got)
-	}
+	assertFieldCount(t, serialized, "CX", 1)
+	assertFieldCount(t, serialized, "CY", 1)
+	assertFieldCount(t, serialized, "RL", 1)
 
 	obj2 := request.Billing{}
 	err = claimdeserializer.DeserializeType(serialized, &obj2)
@@ -426,30 +442,27 @@ func Test_CanRoundTripF6FullFieldSample(t *testing.T) {
 	}
 
 	patient := obj2.Patient
-	if patient.Address.StreetLine1 == nil || *patient.Address.StreetLine1 != "1234 FIRST ADDRESS LINE" {
-		t.Errorf("Patient street line 1 (F6 field 7A) mismatch after round trip. Got: %v", patient.Address.StreetLine1)
-	}
-	if patient.Address.StreetLine2 == nil || *patient.Address.StreetLine2 != "7890 SECOND ADDRESS LINE" {
-		t.Errorf("Patient street line 2 (F6 field 7B) mismatch after round trip. Got: %v", patient.Address.StreetLine2)
-	}
-	if patient.Address.CountryCode == nil || *patient.Address.CountryCode != "US" {
-		t.Errorf("Patient country code (F6 field 1K) mismatch after round trip. Got: %v", patient.Address.CountryCode)
-	}
-	if patient.Species == nil || *patient.Species != "337915000" {
-		t.Errorf("Patient species (F6 field S8) mismatch after round trip. Got: %v", patient.Species)
-	}
+	assertString(t, "Patient street line 1 (F6 field 7A) after round trip", patient.Address.StreetLine1, "1234 FIRST ADDRESS LINE")
+	assertString(t, "Patient street line 2 (F6 field 7B) after round trip", patient.Address.StreetLine2, "7890 SECOND ADDRESS LINE")
+	assertString(t, "Patient country code (F6 field 1K) after round trip", patient.Address.CountryCode, "US")
+	assertString(t, "Patient species (F6 field S8) after round trip", patient.Species, "337915000")
 	if len(patient.Ids) != 1 || patient.Ids[0].Id == nil || *patient.Ids[0].Id != "PATIENTID" {
 		t.Errorf("Patient ids mismatch after round trip. Got: %+v", patient.Ids)
 	}
-	if patient.IdQualifier == nil || *patient.IdQualifier != "99" || patient.Id == nil || *patient.Id != "PATIENTID" {
-		t.Errorf("Patient scalar id mismatch after round trip. Got: %v/%v", patient.IdQualifier, patient.Id)
-	}
+	assertString(t, "Patient scalar id qualifier after round trip", patient.IdQualifier, "99")
+	assertString(t, "Patient scalar id after round trip", patient.Id, "PATIENTID")
 
 	if len(obj2.Claims) != 1 {
 		t.Fatalf("Group count mismatch after round trip. Wanted: 1   Got: %v", len(obj2.Claims))
 	}
 
-	pricing := obj2.Claims[0].Pricing
+	assertF6FullSamplePricingRoundTrip(t, obj2)
+}
+
+func assertF6FullSamplePricingRoundTrip(t *testing.T, obj request.Billing) {
+	t.Helper()
+
+	pricing := obj.Claims[0].Pricing
 	for _, want := range []struct {
 		name string
 		got  *float64
@@ -558,32 +571,21 @@ func Test_D0DualMappedFieldsSerializeOnce(t *testing.T) {
 		t.Fatalf("Failed to deserialize: %v", err)
 	}
 
-	if obj.Patient.IdQualifier == nil || *obj.Patient.IdQualifier != "99" {
-		t.Errorf("Patient id qualifier mismatch. Wanted: 99   Got: %v", obj.Patient.IdQualifier)
-	}
-	if obj.Patient.Id == nil || *obj.Patient.Id != "VERI" {
-		t.Errorf("Patient id mismatch. Wanted: VERI   Got: %v", obj.Patient.Id)
-	}
+	assertString(t, "Patient id qualifier", obj.Patient.IdQualifier, "99")
+	assertString(t, "Patient id", obj.Patient.Id, "VERI")
 	if len(obj.Patient.Ids) != 1 {
 		t.Fatalf("Patient ids count mismatch. Wanted: 1   Got: %v", len(obj.Patient.Ids))
 	}
-	if obj.Patient.Ids[0].Qualifier == nil || *obj.Patient.Ids[0].Qualifier != "99" ||
-		obj.Patient.Ids[0].Id == nil || *obj.Patient.Ids[0].Id != "VERI" {
-		t.Errorf("Patient ids[0] mismatch. Wanted: 99/VERI   Got: %v/%v", obj.Patient.Ids[0].Qualifier, obj.Patient.Ids[0].Id)
-	}
+	assertString(t, "Patient ids[0] qualifier", obj.Patient.Ids[0].Qualifier, "99")
+	assertString(t, "Patient ids[0] id", obj.Patient.Ids[0].Id, "VERI")
 
 	serialized, err := Serialize(&obj)
 	if err != nil {
 		t.Fatalf("Failed to serialize: %v", err)
 	}
 
-	fs := string(ncpdp.FIELD)
-	if got := strings.Count(serialized, fs+"CX"); got != 1 {
-		t.Errorf("Serialized CX occurrence mismatch. Wanted: 1   Got: %v", got)
-	}
-	if got := strings.Count(serialized, fs+"CY"); got != 1 {
-		t.Errorf("Serialized CY occurrence mismatch. Wanted: 1   Got: %v", got)
-	}
+	assertFieldCount(t, serialized, "CX", 1)
+	assertFieldCount(t, serialized, "CY", 1)
 
 	obj2 := request.Billing{}
 	err = claimdeserializer.DeserializeType(serialized, &obj2)
@@ -591,12 +593,8 @@ func Test_D0DualMappedFieldsSerializeOnce(t *testing.T) {
 		t.Fatalf("Failed to deserialize serialized claim: %v", err)
 	}
 
-	if obj2.Patient.IdQualifier == nil || *obj2.Patient.IdQualifier != "99" {
-		t.Errorf("Patient id qualifier mismatch after round trip. Wanted: 99   Got: %v", obj2.Patient.IdQualifier)
-	}
-	if obj2.Patient.Id == nil || *obj2.Patient.Id != "VERI" {
-		t.Errorf("Patient id mismatch after round trip. Wanted: VERI   Got: %v", obj2.Patient.Id)
-	}
+	assertString(t, "Patient id qualifier after round trip", obj2.Patient.IdQualifier, "99")
+	assertString(t, "Patient id after round trip", obj2.Patient.Id, "VERI")
 }
 
 // Test_PreservesTrailingWhitespace verifies that trailing whitespace in field values

--- a/pkg/claimSerializer/claimSerializer_test.go
+++ b/pkg/claimSerializer/claimSerializer_test.go
@@ -237,6 +237,368 @@ func Test_CanUpdateField(t *testing.T) {
 	}
 }
 
+// F6 request header is 58 bytes: version(2) tranCode(2) IIN(8) PCN(10) recordCount(1) SPIQ(2) SPI(15) DOS(8) vendorCertId(10)
+const F6_REQUEST_B1_HEADER = "F6B100880151TEST      1011234567893     20260611SVCID     "
+
+// Raw test constants embed invisible separator bytes, so the F6 sample is built programmatically.
+// F6 (vEB+) has no group separators; the single transaction's segments
+// directly follow the shared segments.
+func buildF6BillingRequest() string {
+	fs := string(ncpdp.FIELD)
+	ss := string(ncpdp.SEGMENT)
+
+	return F6_REQUEST_B1_HEADER +
+		ss + fs + "AM04" + fs + "C2POLICY123" + fs + "C1TESTGROUP" + fs + "C61" +
+		ss + fs + "AM01" + fs + "RR2" + fs + "CX01" + fs + "CY111111111" + fs + "CX02" + fs + "CY222222222" + fs + "C419341231" + fs + "C51" + fs + "CAJOHN" + fs + "0CQUINCY" + fs + "CBDOE" +
+		ss + fs + "AM07" + fs + "EM1" + fs + "D26000001" + fs + "E103" + fs + "D700172240780" + fs + "E70000001000" + fs + "D300" + fs + "D530" + fs + "D61" + fs + "D80" + fs + "DE20260611" + fs + "U701" +
+		ss + fs + "AM19" + fs + "8G1" + fs + "8H01" + fs + "8KQQ" + fs + "8MINTERMEDIARY01"
+}
+
+// F6 response header layout is identical to D0 (31 bytes).
+const F6_RESPONSE_B1_HEADER = "F6B11A011234567893     20260611"
+
+func buildF6BillingResponse() string {
+	fs := string(ncpdp.FIELD)
+	ss := string(ncpdp.SEGMENT)
+
+	return F6_RESPONSE_B1_HEADER +
+		ss + fs + "AM25" + fs + "C1TESTGROUP" + fs + "KR2" + fs + "J701" + fs + "J8PAYER001" + fs + "J702" + fs + "J8PAYER002" + fs + "C2CARD123" +
+		ss + fs + "AM21" + fs + "ANA" +
+		ss + fs + "AM22" + fs + "EM1" + fs + "D26000001"
+}
+
+func Test_CanRoundTripF6BillingRequest(t *testing.T) {
+	obj := request.Billing{}
+	err := claimdeserializer.DeserializeType(buildF6BillingRequest(), &obj)
+	if err != nil {
+		t.Fatalf("Failed to deserialize: %v", err)
+	}
+
+	serialized, err := Serialize(&obj)
+	if err != nil {
+		t.Fatalf("Failed to serialize: %v", err)
+	}
+
+	if len(serialized) < 58 || serialized[:58] != F6_REQUEST_B1_HEADER {
+		t.Errorf("Serialized F6 header mismatch.\nWanted prefix: %q\nGot:           %q", F6_REQUEST_B1_HEADER, serialized[:min(len(serialized), 58)])
+	}
+
+	// Re-deserialize and verify the F6 fields survive the round trip
+	obj2 := request.Billing{}
+	err = claimdeserializer.DeserializeType(serialized, &obj2)
+	if err != nil {
+		t.Fatalf("Failed to deserialize serialized claim: %v", err)
+	}
+
+	if obj2.Header.Value != obj.Header.Value {
+		t.Errorf("Header mismatch after round trip.\nWanted: %+v\nGot:    %+v", obj.Header.Value, obj2.Header.Value)
+	}
+	if obj2.Patient.MiddleName == nil || *obj2.Patient.MiddleName != "QUINCY" {
+		t.Errorf("Patient middle name (F6 field 0C) mismatch after round trip. Wanted: QUINCY   Got: %v", obj2.Patient.MiddleName)
+	}
+
+	if got := strings.Count(serialized, string(ncpdp.GROUP)); got != 0 {
+		t.Errorf("F6 transmissions must not contain group separators. Found: %v", got)
+	}
+
+	// Repeating patient ID: the Ids slice must survive the round trip and the
+	// scalar Id/IdQualifier must not cause duplicate CX/CY field emission.
+	fs := string(ncpdp.FIELD)
+	if got := strings.Count(serialized, fs+"CX"); got != 2 {
+		t.Errorf("Serialized CX occurrence mismatch. Wanted: 2   Got: %v", got)
+	}
+	if got := strings.Count(serialized, fs+"CY"); got != 2 {
+		t.Errorf("Serialized CY occurrence mismatch. Wanted: 2   Got: %v", got)
+	}
+	if len(obj2.Patient.Ids) != 2 {
+		t.Errorf("Patient ids count mismatch after round trip. Wanted: 2   Got: %v", len(obj2.Patient.Ids))
+	}
+	if len(obj2.Claims) != 1 {
+		t.Fatalf("Group count mismatch after round trip. Wanted: 1   Got: %v", len(obj2.Claims))
+	}
+	intermediary := obj2.Claims[0].Intermediary
+	if intermediary.IdCount == nil || *intermediary.IdCount != 1 {
+		t.Errorf("Intermediary id count (F6 field 8G) mismatch after round trip. Wanted: 1   Got: %v", intermediary.IdCount)
+	}
+	if len(intermediary.Ids) != 1 || intermediary.Ids[0].Id == nil || *intermediary.Ids[0].Id != "INTERMEDIARY01" {
+		t.Errorf("Intermediary ids (F6 segment AM19) mismatch after round trip. Got: %+v", intermediary.Ids)
+	}
+}
+
+func Test_CanRoundTripF6BillingResponse(t *testing.T) {
+	obj := response.Billing{}
+	err := claimdeserializer.DeserializeType(buildF6BillingResponse(), &obj)
+	if err != nil {
+		t.Fatalf("Failed to deserialize: %v", err)
+	}
+
+	serialized, err := Serialize(&obj)
+	if err != nil {
+		t.Fatalf("Failed to serialize: %v", err)
+	}
+
+	if got := strings.Count(serialized, string(ncpdp.GROUP)); got != 0 {
+		t.Errorf("F6 transmissions must not contain group separators. Found: %v", got)
+	}
+
+	// Repeating payer ID: the Payers slice must survive the round trip and the
+	// singular Payer must not cause duplicate J7/J8 field emission.
+	fs := string(ncpdp.FIELD)
+	if got := strings.Count(serialized, fs+"J7"); got != 2 {
+		t.Errorf("Serialized J7 occurrence mismatch. Wanted: 2   Got: %v", got)
+	}
+	if got := strings.Count(serialized, fs+"J8"); got != 2 {
+		t.Errorf("Serialized J8 occurrence mismatch. Wanted: 2   Got: %v", got)
+	}
+
+	obj2 := response.Billing{}
+	err = claimdeserializer.DeserializeType(serialized, &obj2)
+	if err != nil {
+		t.Fatalf("Failed to deserialize serialized claim: %v", err)
+	}
+
+	if len(obj2.Insurance.Payers) != 2 {
+		t.Fatalf("Payers count mismatch after round trip. Wanted: 2   Got: %v", len(obj2.Insurance.Payers))
+	}
+	for i, want := range []struct{ qualifier, id string }{{"01", "PAYER001"}, {"02", "PAYER002"}} {
+		got := obj2.Insurance.Payers[i]
+		if got.Qualifier == nil || *got.Qualifier != want.qualifier || got.Id == nil || *got.Id != want.id {
+			t.Errorf("Payers[%d] mismatch after round trip. Wanted: %s/%s   Got: %v/%v", i, want.qualifier, want.id, got.Qualifier, got.Id)
+		}
+	}
+}
+
+const F6_REQUEST_FULL_HEADER = "F6B188015600PCN12345671011234567893     20260611VENDORCERT"
+
+// Built from the raw F6 sample (RawSample_F6.txt) with CRLF line breaks
+// removed. F6 has no group separator: AM11 follows the shared segments
+// directly and is assigned to the single claim group by segment ID.
+func buildF6FullBillingRequest() string {
+	fs := string(ncpdp.FIELD)
+	ss := string(ncpdp.SEGMENT)
+
+	return F6_REQUEST_FULL_HEADER +
+		ss + fs + "AM04" + fs + "C2CARDID" + fs + "CCCARDFIRST" + fs + "CDCARDLAST" + fs + "FOPLANID" + fs + "C90" + fs + "C1D0PAID" + fs + "C3001" + fs + "C61" + fs + "2AMEDIGAPID" + fs + "2BSC" + fs + "2DN" + fs + "N5MEDICAIDIDNUMBER" +
+		ss + fs + "AM01" + fs + "RR1" + fs + "CX99" + fs + "CYPATIENTID" + fs + "C419850601" + fs + "C51" + fs + "CAFIRSTNAME" + fs + "CBLASTNAME" + fs + "7A1234 FIRST ADDRESS LINE" + fs + "7B7890 SECOND ADDRESS LINE" + fs + "CNROEBUCK" + fs + "COSC" + fs + "CP293764444" + fs + "1KUS" + fs + "CQ8645555555" + fs + "C701" + fs + "CZEMPLOYERID" + fs + "2C1" + fs + "HNEMAIL@DOMAIN.COM" + fs + "4X1" + fs + "S8337915000" +
+		ss + fs + "AM11" + fs + "D91234567H" + fs + "DC250{" + fs + "BE200{" + fs + "DX" + fs + "E350{" + fs + "H71" + fs + "H801" + fs + "H975E" + fs + "RK1" + fs + "RLAB" + fs + "HA43B" + fs + "GE12345G" + fs + "HE10000" + fs + "JE02" + fs + "DQ1345670{" + fs + "DU1247532B" + fs + "DN01"
+}
+
+func Test_CanRoundTripF6FullFieldSample(t *testing.T) {
+	obj := request.Billing{}
+	err := claimdeserializer.DeserializeType(buildF6FullBillingRequest(), &obj)
+	if err != nil {
+		t.Fatalf("Failed to deserialize: %v", err)
+	}
+
+	serialized, err := Serialize(&obj)
+	if err != nil {
+		t.Fatalf("Failed to serialize: %v", err)
+	}
+
+	if len(serialized) < 58 || serialized[:58] != F6_REQUEST_FULL_HEADER {
+		t.Errorf("Serialized F6 header mismatch.\nWanted prefix: %q\nGot:           %q", F6_REQUEST_FULL_HEADER, serialized[:min(len(serialized), 58)])
+	}
+
+	if got := strings.Count(serialized, string(ncpdp.GROUP)); got != 0 {
+		t.Errorf("F6 transmissions must not contain group separators. Found: %v", got)
+	}
+
+	// Single-occurrence dual-mapped patient ID must serialize exactly once.
+	fs := string(ncpdp.FIELD)
+	if got := strings.Count(serialized, fs+"CX"); got != 1 {
+		t.Errorf("Serialized CX occurrence mismatch. Wanted: 1   Got: %v", got)
+	}
+	if got := strings.Count(serialized, fs+"CY"); got != 1 {
+		t.Errorf("Serialized CY occurrence mismatch. Wanted: 1   Got: %v", got)
+	}
+	if got := strings.Count(serialized, fs+"RL"); got != 1 {
+		t.Errorf("Serialized RL occurrence mismatch. Wanted: 1   Got: %v", got)
+	}
+
+	obj2 := request.Billing{}
+	err = claimdeserializer.DeserializeType(serialized, &obj2)
+	if err != nil {
+		t.Fatalf("Failed to deserialize serialized claim: %v", err)
+	}
+
+	if obj2.Header.Value != obj.Header.Value {
+		t.Errorf("Header mismatch after round trip.\nWanted: %+v\nGot:    %+v", obj.Header.Value, obj2.Header.Value)
+	}
+
+	patient := obj2.Patient
+	if patient.Address.StreetLine1 == nil || *patient.Address.StreetLine1 != "1234 FIRST ADDRESS LINE" {
+		t.Errorf("Patient street line 1 (F6 field 7A) mismatch after round trip. Got: %v", patient.Address.StreetLine1)
+	}
+	if patient.Address.StreetLine2 == nil || *patient.Address.StreetLine2 != "7890 SECOND ADDRESS LINE" {
+		t.Errorf("Patient street line 2 (F6 field 7B) mismatch after round trip. Got: %v", patient.Address.StreetLine2)
+	}
+	if patient.Address.CountryCode == nil || *patient.Address.CountryCode != "US" {
+		t.Errorf("Patient country code (F6 field 1K) mismatch after round trip. Got: %v", patient.Address.CountryCode)
+	}
+	if patient.Species == nil || *patient.Species != "337915000" {
+		t.Errorf("Patient species (F6 field S8) mismatch after round trip. Got: %v", patient.Species)
+	}
+	if len(patient.Ids) != 1 || patient.Ids[0].Id == nil || *patient.Ids[0].Id != "PATIENTID" {
+		t.Errorf("Patient ids mismatch after round trip. Got: %+v", patient.Ids)
+	}
+	if patient.IdQualifier == nil || *patient.IdQualifier != "99" || patient.Id == nil || *patient.Id != "PATIENTID" {
+		t.Errorf("Patient scalar id mismatch after round trip. Got: %v/%v", patient.IdQualifier, patient.Id)
+	}
+
+	if len(obj2.Claims) != 1 {
+		t.Fatalf("Group count mismatch after round trip. Wanted: 1   Got: %v", len(obj2.Claims))
+	}
+
+	pricing := obj2.Claims[0].Pricing
+	for _, want := range []struct {
+		name string
+		got  *float64
+		val  float64
+	}{
+		{"ingredient cost (D9)", pricing.IngredientCostSubmitted, 123456.78},
+		{"dispensing fee (DC)", pricing.DispensingFeeSubmitted, 25.00},
+		{"professional service fee (BE)", pricing.ProfessionalServiceFeeSubmitted, 20.00},
+		{"patient paid amount (DX, empty in source)", pricing.PatientPaidAmountSubmitted, 0},
+		{"incentive amount (E3)", pricing.IncentiveAmountSubmitted, 5.00},
+		{"flat sales tax (HA)", pricing.FlatSalesTaxAmountSubmitted, 4.32},
+		{"percentage sales tax amount (GE)", pricing.PercentageSalesTaxAmountSubmitted, 1234.57},
+		{"percentage sales tax rate (HE)", pricing.PercentageSalesTaxRateSubmitted, 1.0000},
+		{"usual and customary charge (DQ)", pricing.UsualAndCustmaryCharge, 134567.00},
+		{"gross amount due (DU)", pricing.GrossAmountDue, 124753.22},
+	} {
+		if want.got == nil || *want.got != want.val {
+			t.Errorf("Pricing %s mismatch after round trip. Wanted: %v   Got: %v", want.name, want.val, want.got)
+		}
+	}
+	if len(pricing.OtherAmountClaimSubmitted) != 1 || pricing.OtherAmountClaimSubmitted[0].AmountSubmitted == nil || *pricing.OtherAmountClaimSubmitted[0].AmountSubmitted != 7.55 {
+		t.Errorf("Pricing other amounts (H8/H9) mismatch after round trip. Got: %+v", pricing.OtherAmountClaimSubmitted)
+	}
+	if len(pricing.RegulatoryFees) != 1 || pricing.RegulatoryFees[0].TypeCode == nil || *pricing.RegulatoryFees[0].TypeCode != "AB" {
+		t.Errorf("Pricing regulatory fees (RK/RL) mismatch after round trip. Got: %+v", pricing.RegulatoryFees)
+	}
+}
+
+// F6 (vEB+) allows only a single transaction per transmission, and without
+// group separators multiple claim groups cannot be represented.
+func Test_F6SerializeRejectsMultipleClaimGroups(t *testing.T) {
+	obj := request.Billing{}
+	err := claimdeserializer.DeserializeType(buildF6BillingRequest(), &obj)
+	if err != nil {
+		t.Fatalf("Failed to deserialize: %v", err)
+	}
+
+	obj.Claims = append(obj.Claims, obj.Claims[0])
+
+	_, err = Serialize(&obj)
+	if err == nil {
+		t.Fatal("Expected error serializing an F6 claim with multiple claim groups, got nil")
+	}
+}
+
+func Test_CanRoundTripF6PricingRegulatoryFees(t *testing.T) {
+	fs := string(ncpdp.FIELD)
+	ss := string(ncpdp.SEGMENT)
+
+	rawData := F6_REQUEST_B1_HEADER +
+		ss + fs + "AM04" + fs + "C2POLICY123" + fs + "C61" +
+		ss + fs + "AM07" + fs + "EM1" + fs + "D26000001" + fs + "E103" + fs + "D700172240780" +
+		ss + fs + "AM11" + fs + "D9100{" + fs + "RK2" + fs + "RL01" + fs + "RL02"
+
+	obj := request.Billing{}
+	err := claimdeserializer.DeserializeType(rawData, &obj)
+	if err != nil {
+		t.Fatalf("Failed to deserialize: %v", err)
+	}
+
+	if len(obj.Claims) != 1 {
+		t.Fatalf("Group count mismatch. Wanted: 1   Got: %v", len(obj.Claims))
+	}
+
+	pricing := obj.Claims[0].Pricing
+	if pricing.RegulatoryFeeCount == nil || *pricing.RegulatoryFeeCount != 2 {
+		t.Errorf("Regulatory fee count (F6 field RK) mismatch. Wanted: 2   Got: %v", pricing.RegulatoryFeeCount)
+	}
+	if len(pricing.RegulatoryFees) != 2 {
+		t.Fatalf("Regulatory fees count mismatch. Wanted: 2   Got: %v", len(pricing.RegulatoryFees))
+	}
+	for i, want := range []string{"01", "02"} {
+		got := pricing.RegulatoryFees[i].TypeCode
+		if got == nil || *got != want {
+			t.Errorf("Regulatory fee type code (F6 field RL) [%d] mismatch. Wanted: %s   Got: %v", i, want, got)
+		}
+	}
+
+	serialized, err := Serialize(&obj)
+	if err != nil {
+		t.Fatalf("Failed to serialize: %v", err)
+	}
+
+	if got := strings.Count(serialized, fs+"RL"); got != 2 {
+		t.Errorf("Serialized RL occurrence mismatch. Wanted: 2   Got: %v", got)
+	}
+
+	obj2 := request.Billing{}
+	err = claimdeserializer.DeserializeType(serialized, &obj2)
+	if err != nil {
+		t.Fatalf("Failed to deserialize serialized claim: %v", err)
+	}
+
+	if len(obj2.Claims) != 1 || len(obj2.Claims[0].Pricing.RegulatoryFees) != 2 {
+		t.Errorf("Regulatory fees not preserved through round trip. Got: %+v", obj2.Claims)
+	}
+}
+
+// Test_D0DualMappedFieldsSerializeOnce guards the serializer skip logic for D0
+// data: a single CX/CY occurrence populates both the backward-compatible
+// scalars and the repeating Ids slice, but must serialize exactly once.
+func Test_D0DualMappedFieldsSerializeOnce(t *testing.T) {
+	obj := request.Billing{}
+	err := claimdeserializer.DeserializeType(REQUEST_B1, &obj)
+	if err != nil {
+		t.Fatalf("Failed to deserialize: %v", err)
+	}
+
+	if obj.Patient.IdQualifier == nil || *obj.Patient.IdQualifier != "99" {
+		t.Errorf("Patient id qualifier mismatch. Wanted: 99   Got: %v", obj.Patient.IdQualifier)
+	}
+	if obj.Patient.Id == nil || *obj.Patient.Id != "VERI" {
+		t.Errorf("Patient id mismatch. Wanted: VERI   Got: %v", obj.Patient.Id)
+	}
+	if len(obj.Patient.Ids) != 1 {
+		t.Fatalf("Patient ids count mismatch. Wanted: 1   Got: %v", len(obj.Patient.Ids))
+	}
+	if obj.Patient.Ids[0].Qualifier == nil || *obj.Patient.Ids[0].Qualifier != "99" ||
+		obj.Patient.Ids[0].Id == nil || *obj.Patient.Ids[0].Id != "VERI" {
+		t.Errorf("Patient ids[0] mismatch. Wanted: 99/VERI   Got: %v/%v", obj.Patient.Ids[0].Qualifier, obj.Patient.Ids[0].Id)
+	}
+
+	serialized, err := Serialize(&obj)
+	if err != nil {
+		t.Fatalf("Failed to serialize: %v", err)
+	}
+
+	fs := string(ncpdp.FIELD)
+	if got := strings.Count(serialized, fs+"CX"); got != 1 {
+		t.Errorf("Serialized CX occurrence mismatch. Wanted: 1   Got: %v", got)
+	}
+	if got := strings.Count(serialized, fs+"CY"); got != 1 {
+		t.Errorf("Serialized CY occurrence mismatch. Wanted: 1   Got: %v", got)
+	}
+
+	obj2 := request.Billing{}
+	err = claimdeserializer.DeserializeType(serialized, &obj2)
+	if err != nil {
+		t.Fatalf("Failed to deserialize serialized claim: %v", err)
+	}
+
+	if obj2.Patient.IdQualifier == nil || *obj2.Patient.IdQualifier != "99" {
+		t.Errorf("Patient id qualifier mismatch after round trip. Wanted: 99   Got: %v", obj2.Patient.IdQualifier)
+	}
+	if obj2.Patient.Id == nil || *obj2.Patient.Id != "VERI" {
+		t.Errorf("Patient id mismatch after round trip. Wanted: VERI   Got: %v", obj2.Patient.Id)
+	}
+}
+
 // Test_PreservesTrailingWhitespace verifies that trailing whitespace in field values
 // is preserved through the deserialize -> serialize roundtrip.
 func Test_PreservesTrailingWhitespace(t *testing.T) {

--- a/pkg/claimSerializer/concurrency_test.go
+++ b/pkg/claimSerializer/concurrency_test.go
@@ -32,30 +32,7 @@ func Test_SerializeIsConcurrencySafe(t *testing.T) {
 			defer wg.Done()
 
 			for i := 0; i < iterations; i++ {
-				// Serialize the shared object (concurrent reads of one struct)
-				got, err := Serialize(&shared)
-				if err != nil {
-					t.Errorf("Failed to serialize shared object: %v", err)
-					return
-				}
-				if got != baseline {
-					t.Errorf("Serialized output mismatch under concurrency.\nWanted: %q\nGot:    %q", baseline, got)
-					return
-				}
-
-				// Full round trip with a goroutine-local object
-				local := request.Billing{}
-				if err := claimdeserializer.DeserializeType(buildF6BillingRequest(), &local); err != nil {
-					t.Errorf("Failed to deserialize local object: %v", err)
-					return
-				}
-				got, err = Serialize(&local)
-				if err != nil {
-					t.Errorf("Failed to serialize local object: %v", err)
-					return
-				}
-				if got != baseline {
-					t.Errorf("Local round-trip output mismatch under concurrency.\nWanted: %q\nGot:    %q", baseline, got)
+				if !serializeSharedConcurrently(t, &shared, baseline) || !roundTripLocalConcurrently(t, baseline) {
 					return
 				}
 			}
@@ -63,4 +40,46 @@ func Test_SerializeIsConcurrencySafe(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+// Serialize the shared object (concurrent reads of one struct).
+func serializeSharedConcurrently(t *testing.T, shared *request.Billing, baseline string) bool {
+	t.Helper()
+
+	got, err := Serialize(shared)
+	if err != nil {
+		t.Errorf("Failed to serialize shared object: %v", err)
+		return false
+	}
+
+	if got != baseline {
+		t.Errorf("Serialized output mismatch under concurrency.\nWanted: %q\nGot:    %q", baseline, got)
+		return false
+	}
+
+	return true
+}
+
+// Full round trip with a goroutine-local object.
+func roundTripLocalConcurrently(t *testing.T, baseline string) bool {
+	t.Helper()
+
+	local := request.Billing{}
+	if err := claimdeserializer.DeserializeType(buildF6BillingRequest(), &local); err != nil {
+		t.Errorf("Failed to deserialize local object: %v", err)
+		return false
+	}
+
+	got, err := Serialize(&local)
+	if err != nil {
+		t.Errorf("Failed to serialize local object: %v", err)
+		return false
+	}
+
+	if got != baseline {
+		t.Errorf("Local round-trip output mismatch under concurrency.\nWanted: %q\nGot:    %q", baseline, got)
+		return false
+	}
+
+	return true
 }

--- a/pkg/claimSerializer/concurrency_test.go
+++ b/pkg/claimSerializer/concurrency_test.go
@@ -1,0 +1,66 @@
+package claimserializer
+
+import (
+	"sync"
+	"testing"
+
+	claimdeserializer "github.com/transactrx/NCPDPSerDe/pkg/claimDeserializer"
+	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp/request"
+)
+
+// Serialization shares cached field-code sets and segment definitions across
+// goroutines, so concurrent serialization of the same object must be safe and
+// always produce identical output. Run with -race to catch data races.
+func Test_SerializeIsConcurrencySafe(t *testing.T) {
+	shared := request.Billing{}
+	if err := claimdeserializer.DeserializeType(buildF6BillingRequest(), &shared); err != nil {
+		t.Fatalf("Failed to deserialize: %v", err)
+	}
+
+	baseline, err := Serialize(&shared)
+	if err != nil {
+		t.Fatalf("Failed to serialize baseline: %v", err)
+	}
+
+	const goroutines = 10
+	const iterations = 25
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for i := 0; i < iterations; i++ {
+				// Serialize the shared object (concurrent reads of one struct)
+				got, err := Serialize(&shared)
+				if err != nil {
+					t.Errorf("Failed to serialize shared object: %v", err)
+					return
+				}
+				if got != baseline {
+					t.Errorf("Serialized output mismatch under concurrency.\nWanted: %q\nGot:    %q", baseline, got)
+					return
+				}
+
+				// Full round trip with a goroutine-local object
+				local := request.Billing{}
+				if err := claimdeserializer.DeserializeType(buildF6BillingRequest(), &local); err != nil {
+					t.Errorf("Failed to deserialize local object: %v", err)
+					return
+				}
+				got, err = Serialize(&local)
+				if err != nil {
+					t.Errorf("Failed to serialize local object: %v", err)
+					return
+				}
+				if got != baseline {
+					t.Errorf("Local round-trip output mismatch under concurrency.\nWanted: %q\nGot:    %q", baseline, got)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/pkg/ncpdp/constants.go
+++ b/pkg/ncpdp/constants.go
@@ -18,6 +18,7 @@ const (
 // NCPDP Versions
 const (
 	D0 = "D0"
+	F6 = "F6"
 )
 
 // Response Status Codes

--- a/pkg/ncpdp/header.go
+++ b/pkg/ncpdp/header.go
@@ -10,7 +10,10 @@ import (
 	stringutils "github.com/transactrx/NCPDPSerDe/pkg/stringUtils"
 )
 
-const layoutTag = "layout"
+const (
+	layoutTag   = "layout"
+	layoutF6Tag = "layoutF6"
+)
 
 type NcpdpHeader[V RequestHeader | ResponseHeader | FinancialRequestHeader | FinancialResponseHeader] struct {
 	RawValue string
@@ -18,16 +21,18 @@ type NcpdpHeader[V RequestHeader | ResponseHeader | FinancialRequestHeader | Fin
 	Value    V
 }
 
+// RequestHeader holds the parsed request header fields for both D0 and F6.
+// In F6 the field 101-A1 is called IIN; this code reuses Bin to hold either value.
 type RequestHeader struct {
-	Bin                           string `layout:"start=0,length=6,order=1"`
-	Version                       string `layout:"start=6,length=2,order=2"`
-	TransactionCode               string `layout:"start=8,length=2,order=3"`
-	Pcn                           string `layout:"start=10,length=10,order=4"`
-	RecordCount                   int    `layout:"start=20,length=1,order=5"`
-	ServiceProviderIdQualifier    string `layout:"start=21,length=2,order=6"`
-	ServiceProviderId             string `layout:"start=23,length=15,order=7"`
-	DateOfService                 string `layout:"start=38,length=8,order=8"`
-	SoftwareVendorCertificationId string `layout:"start=46,length=10,order=9"`
+	Bin                           string `layout:"start=0,length=6,order=1"   layoutF6:"start=4,length=8,order=3"`
+	Version                       string `layout:"start=6,length=2,order=2"   layoutF6:"start=0,length=2,order=1"`
+	TransactionCode               string `layout:"start=8,length=2,order=3"   layoutF6:"start=2,length=2,order=2"`
+	Pcn                           string `layout:"start=10,length=10,order=4" layoutF6:"start=12,length=10,order=4"`
+	RecordCount                   int    `layout:"start=20,length=1,order=5"  layoutF6:"start=22,length=1,order=5"`
+	ServiceProviderIdQualifier    string `layout:"start=21,length=2,order=6"  layoutF6:"start=23,length=2,order=6"`
+	ServiceProviderId             string `layout:"start=23,length=15,order=7" layoutF6:"start=25,length=15,order=7"`
+	DateOfService                 string `layout:"start=38,length=8,order=8"  layoutF6:"start=40,length=8,order=8"`
+	SoftwareVendorCertificationId string `layout:"start=46,length=10,order=9" layoutF6:"start=48,length=10,order=9"`
 }
 
 type ResponseHeader struct {
@@ -80,13 +85,15 @@ func (h *NcpdpHeader[V]) BuildNcpdpHeader() error {
 	headerType := reflect.TypeOf(h.Value)
 	objectRef := reflect.ValueOf(h.Value)
 
+	tagName := resolveLayoutTagName(getStructVersion(objectRef))
+
 	// Compile list of fields by order
 	mappedFields := make(map[int]fieldLayout)
 
 	for i := 0; i < headerType.NumField(); i++ {
 		field := headerType.Field(i)
 
-		tag := field.Tag.Get(layoutTag)
+		tag := resolveFieldTag(field, tagName)
 		if tag != Empty {
 			layout, err := getLayoutFromTag(tag)
 			if err != nil {
@@ -136,13 +143,15 @@ func (h *NcpdpHeader[V]) ParseNcpdpHeader() error {
 	headerType := reflect.TypeOf(item)
 	objectRef := reflect.ValueOf(item)
 
+	tagName := resolveLayoutTagName(detectVersionFromRaw(h.RawValue))
+
 	//Set fields with layout tags
 	for i := 0; i < headerType.Elem().NumField(); i++ {
 		field := headerType.Elem().Field(i)
 		prop := objectRef.Elem().FieldByName(field.Name)
 
 		if prop.CanSet() {
-			tag := field.Tag.Get(layoutTag)
+			tag := resolveFieldTag(field, tagName)
 
 			if tag != Empty {
 				layout, err := getLayoutFromTag(tag)
@@ -195,4 +204,46 @@ func getLayoutFromTag(tag string) (Layout, error) {
 	}
 
 	return layout, nil
+}
+
+// resolveLayoutTagName returns the struct tag name to use for the given NCPDP version.
+func resolveLayoutTagName(version string) string {
+	if strings.HasPrefix(version, "F") {
+		return layoutF6Tag
+	}
+	return layoutTag
+}
+
+// resolveFieldTag returns the tag value for the requested tag name, falling back to the default layout tag if absent.
+func resolveFieldTag(field reflect.StructField, tagName string) string {
+	if tagName != layoutTag {
+		if tag := field.Tag.Get(tagName); tag != Empty {
+			return tag
+		}
+	}
+	return field.Tag.Get(layoutTag)
+}
+
+// detectVersionFromRaw inspects the first bytes of the raw header to determine the NCPDP version.
+// Returns the version prefix (e.g., "F6") or empty string if it cannot be determined.
+func detectVersionFromRaw(raw string) string {
+	if len(raw) >= 2 && raw[0] == 'F' {
+		return raw[:2]
+	}
+	return Empty
+}
+
+// getStructVersion reads the Version field from a header struct value if present.
+func getStructVersion(v reflect.Value) string {
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return Empty
+	}
+	vf := v.FieldByName("Version")
+	if !vf.IsValid() || vf.Kind() != reflect.String {
+		return Empty
+	}
+	return vf.String()
 }

--- a/pkg/ncpdp/header_test.go
+++ b/pkg/ncpdp/header_test.go
@@ -168,6 +168,67 @@ func TestParsingResponseHeaderShorterThanLayoutReturnsError(t *testing.T) {
 	}
 }
 
+var f6RequestHeaderTests = []requestHeaderValueTest{
+	{
+		claim:  "F6F100880151TEST      1011234567893     20260611SVCID     ",
+		header: RequestHeader{Bin: "00880151", Version: "F6", TransactionCode: "F1", Pcn: "TEST", RecordCount: 1, ServiceProviderIdQualifier: "01", ServiceProviderId: "1234567893", DateOfService: "20260611", SoftwareVendorCertificationId: "SVCID"},
+	},
+	{
+		claim:  "F6F161003800          4070000240        20260611          ",
+		header: RequestHeader{Bin: "61003800", Version: "F6", TransactionCode: "F1", Pcn: "", RecordCount: 4, ServiceProviderIdQualifier: "07", ServiceProviderId: "0000240", DateOfService: "20260611", SoftwareVendorCertificationId: ""},
+	},
+}
+
+func TestParsingF6RequestHeader(t *testing.T) {
+	for _, test := range f6RequestHeaderTests {
+		header := NcpdpHeader[RequestHeader]{
+			RawValue: test.claim,
+		}
+
+		err := header.ParseNcpdpHeader()
+
+		if err != nil {
+			t.Error(err)
+			break
+		}
+
+		if header.Value != test.header {
+			t.Errorf("Header mismatch. Wanted: %+v   Got: %+v", test.header, header.Value)
+		}
+
+		if header.Size != 58 {
+			t.Errorf("Header size mismatch. Wanted: '58'   Got: %q", header.Size)
+		}
+	}
+}
+
+func TestBuildingF6RequestHeader(t *testing.T) {
+	for _, test := range f6RequestHeaderTests {
+		header := NcpdpHeader[RequestHeader]{
+			Value: test.header,
+		}
+
+		err := header.BuildNcpdpHeader()
+		if err != nil {
+			t.Error(err)
+			break
+		}
+
+		if header.RawValue != test.claim {
+			t.Errorf("RawValue mismatch. Wanted: %q   Got: %q", test.claim, header.RawValue)
+		}
+	}
+}
+
+func TestParsingF6RequestHeaderShorterThanLayoutReturnsError(t *testing.T) {
+	for _, raw := range []string{"F", "F6F100880151"} {
+		header := NcpdpHeader[RequestHeader]{RawValue: raw}
+		if err := header.ParseNcpdpHeader(); err == nil {
+			t.Errorf("expected error for raw %q (length %d), got nil", raw, len(raw))
+		}
+	}
+}
+
 func TestParsingRequestHeaderShorterThanLayoutReturnsError(t *testing.T) {
 	for _, raw := range []string{"8", "880151D0B1"} {
 		header := NcpdpHeader[RequestHeader]{RawValue: raw}

--- a/pkg/ncpdp/request/billing.go
+++ b/pkg/ncpdp/request/billing.go
@@ -34,6 +34,7 @@ type BillingRecord struct {
 	AdditionalDocumentation requestsegment.AdditionalDocumentation `segment:"code=AM14,order=11"`
 	Facility                requestsegment.Facility                `segment:"code=AM15,order=12"`
 	Narrative               requestsegment.Narrative               `segment:"code=AM16,order=13"`
+	Intermediary            requestsegment.Intermediary            `segment:"code=AM19,order=14"`
 	DataCollection          requestsegment.DataCollection          `segment:"code=AMXX,order=99"`
 	DynamicSegments         []dynamic.DynamicStruct                `segment:"code=dynamic,order=100"`
 }

--- a/pkg/ncpdp/request/eligibility.go
+++ b/pkg/ncpdp/request/eligibility.go
@@ -16,6 +16,7 @@ type Eligibility struct {
 	Pharmacy                requestsegment.PharmacyProvider        `segment:"code=AM02,order=3"`
 	Prescriber              requestsegment.Prescriber              `segment:"code=AM03,order=4"`
 	AdditionalDocumentation requestsegment.AdditionalDocumentation `segment:"code=AM14,order=5"`
+	LastKnown4Rx            requestsegment.LastKnown4Rx            `segment:"code=AM37,order=6"`
 	DataCollection          requestsegment.DataCollection          `segment:"code=AMXX,order=99"`
 	DynamicSegments         []dynamic.DynamicStruct                `segment:"code=dynamic,order=100"`
 }

--- a/pkg/ncpdp/request/information.go
+++ b/pkg/ncpdp/request/information.go
@@ -28,6 +28,7 @@ type InformationRecord struct {
 	WorkersCompensation requestsegment.WorkersCompensation `segment:"code=AM06,order=4"`
 	Dur                 requestsegment.Dur                 `segment:"code=AM08,order=5"`
 	Clinical            requestsegment.Clinical            `segment:"code=AM13,order=7"`
+	PayerIdentification requestsegment.NTransactionPayerIdentification `segment:"code=AM38,order=8"`
 	DataCollection      requestsegment.DataCollection      `segment:"code=AMXX,order=99"`
 	DynamicSegments     []dynamic.DynamicStruct            `segment:"code=dynamic,order=100"`
 }

--- a/pkg/ncpdp/request/informationRebill.go
+++ b/pkg/ncpdp/request/informationRebill.go
@@ -28,6 +28,7 @@ type InformationRebillRecord struct {
 	WorkersCompensation requestsegment.WorkersCompensation `segment:"code=AM06,order=4"`
 	Dur                 requestsegment.Dur                 `segment:"code=AM08,order=5"`
 	Clinical            requestsegment.Clinical            `segment:"code=AM13,order=7"`
+	PayerIdentification requestsegment.NTransactionPayerIdentification `segment:"code=AM38,order=8"`
 	DataCollection      requestsegment.DataCollection      `segment:"code=AMXX,order=99"`
 	DynamicSegments     []dynamic.DynamicStruct            `segment:"code=dynamic,order=100"`
 }

--- a/pkg/ncpdp/request/informationReversal.go
+++ b/pkg/ncpdp/request/informationReversal.go
@@ -21,7 +21,8 @@ type InformationReversal struct {
 
 type InformationReversalRecord struct {
 	Raw             string                        `field:"code=rawgroup"`
-	Claim           requestsegment.Claim          `segment:"code=AM07,order=1"`
-	DataCollection  requestsegment.DataCollection `segment:"code=AMXX,order=99"`
+	Claim               requestsegment.Claim                           `segment:"code=AM07,order=1"`
+	PayerIdentification requestsegment.NTransactionPayerIdentification `segment:"code=AM38,order=2"`
+	DataCollection      requestsegment.DataCollection                  `segment:"code=AMXX,order=99"`
 	DynamicSegments []dynamic.DynamicStruct       `segment:"code=dynamic,order=100"`
 }

--- a/pkg/ncpdp/request/priorAuthorization.go
+++ b/pkg/ncpdp/request/priorAuthorization.go
@@ -34,6 +34,7 @@ type PriorAuthorizationRecord struct {
 	AdditionalDocumentation requestsegment.AdditionalDocumentation             `segment:"code=AM14,order=11"`
 	Facility                requestsegment.Facility                            `segment:"code=AM15,order=12"`
 	Narrative               requestsegment.Narrative                           `segment:"code=AM16,order=13"`
+	Intermediary            requestsegment.Intermediary                        `segment:"code=AM19,order=14"`
 	DataCollection          requestsegment.DataCollection                      `segment:"code=AMXX,order=99"`
 	DynamicSegments         []dynamic.DynamicStruct                            `segment:"code=dynamic,order=100"`
 }

--- a/pkg/ncpdp/request/rebill.go
+++ b/pkg/ncpdp/request/rebill.go
@@ -34,6 +34,7 @@ type RebillRecord struct {
 	AdditionalDocumentation requestsegment.AdditionalDocumentation `segment:"code=AM14,order=11"`
 	Facility                requestsegment.Facility                `segment:"code=AM15,order=12"`
 	Narrative               requestsegment.Narrative               `segment:"code=AM16,order=13"`
+	Intermediary            requestsegment.Intermediary            `segment:"code=AM19,order=14"`
 	DataCollection          requestsegment.DataCollection          `segment:"code=AMXX,order=99"`
 	DynamicSegments         []dynamic.DynamicStruct                `segment:"code=dynamic,order=100"`
 }

--- a/pkg/ncpdp/request/requestSegment/claim.go
+++ b/pkg/ncpdp/request/requestSegment/claim.go
@@ -44,6 +44,22 @@ type Claim struct {
 	CompoundType                       *string                 `field:"code=G1,order=41"`
 	MedicaidSubrogationControlNumber   *string                 `field:"code=N4,order=42"`
 	PharmacyServiceType                *string                 `field:"code=U7,order=43"`
+	ReconciliationId                   *string                 `field:"code=34,order=44"`
+	SubmissionTypeCodeCount            *int                    `field:"code=KZ,order=49"`
+	SubmissionTypeCodes                []SubmissionTypeCode
+	MultipleOrderGroupId               *string                 `field:"code=M3,order=51"`
+	MultipleOrderGroupReasonCode       *string                 `field:"code=M4,order=52"`
+	TotalPrescribedQuantityRemaining   *float64                `field:"code=KW,decimalPlaces=3,order=53"`
+	PreparationEnvironmentType         *string                 `field:"code=KU,order=54"`
+	PreparationEnvironmentEventCode    *string                 `field:"code=KT,order=55"`
+	TimeOfService                      *string                 `field:"code=Y6,order=56"`
+	SalesTransactionId                 *string                 `field:"code=ZF,order=57"`
+	ReportedAdjudicatedProgramType     *string                 `field:"code=ZS,order=58"`
+	OriginalManufacturerProduct        OriginalManufacturerProduct
+	LTPACDispenseFrequency             *int                    `field:"code=KK,order=61"`
+	LTPACBillingMethodology            *string                 `field:"code=KH,order=62"`
+	NumberOfLTPACDispensingEvents      *int                    `field:"code=KM,order=63"`
+	DoNotDispenseBeforeDate            *time.Time              `field:"code=K9,format=YYYYMMdd,order=64"`
 	DynamicFields                      []dynamic.DynamicStruct `field:"code=dynamic"`
 }
 
@@ -53,8 +69,12 @@ type PrescriptionServiceReference struct {
 }
 
 type AssociatedPrescriptionService struct {
-	Number *string    `field:"code=EN,order=6"`
-	Date   *time.Time `field:"code=EP,format=YYYYMMdd,order=7"`
+	Number                  *string    `field:"code=EN,order=6"`
+	Date                    *time.Time `field:"code=EP,format=YYYYMMdd,order=7"`
+	ReferenceNumberQualifier *string   `field:"code=XZ,order=45"`
+	ProviderIdQualifier      *string   `field:"code=XX,order=46"`
+	ProviderId               *string   `field:"code=XY,order=47"`
+	FillNumber               *string   `field:"code=X0,order=48"`
 }
 
 type ProductService struct {
@@ -84,4 +104,13 @@ type ProcedureModifierCode struct {
 
 type SubmissionClarificationCode struct {
 	Code *string `field:"code=DK,order=19"`
+}
+
+type SubmissionTypeCode struct {
+	Code *string `field:"code=K8,order=50"`
+}
+
+type OriginalManufacturerProduct struct {
+	Qualifier *string `field:"code=4P,order=59"`
+	Id        *string `field:"code=4N,order=60"`
 }

--- a/pkg/ncpdp/request/requestSegment/compound.go
+++ b/pkg/ncpdp/request/requestSegment/compound.go
@@ -10,6 +10,7 @@ type Compound struct {
 
 	DosageFormDescriptionCode   *string `field:"code=EF,order=2"`
 	DispensingUnitFormIndicator *string `field:"code=EG,order=3"`
+	LevelOfComplexity           *string `field:"code=AG,order=12"`
 
 	IngredientCount *int `field:"code=EC,order=4"`
 	Ingredients     []CompoundIngredient

--- a/pkg/ncpdp/request/requestSegment/coordinationOfBenefits.go
+++ b/pkg/ncpdp/request/requestSegment/coordinationOfBenefits.go
@@ -34,6 +34,25 @@ type OtherPayer struct {
 
 	BenefitStageCount   *int `field:"code=MU,order=16"`
 	BenefitStageAmounts []BenefitStage
+
+	AdjudicatedProgramType       *string `field:"code=9T,order=19"`
+	ReconciliationId             *string `field:"code=9V,order=20"`
+	PercentageTaxExemptIndicator *string `field:"code=P7,order=21"`
+
+	RegulatoryFeeTypeCount *int `field:"code=P9,order=22"`
+	RegulatoryFees         []OtherPayerRegulatoryFee
+
+	BenefitStageIndicatorCount *int `field:"code=9W,order=25"`
+	BenefitStageIndicators     []BenefitStageIndicator
+}
+
+type OtherPayerRegulatoryFee struct {
+	TypeCode        *string `field:"code=RN,order=23"`
+	ExemptIndicator *string `field:"code=P8,order=24"`
+}
+
+type BenefitStageIndicator struct {
+	Indicator *string `field:"code=9X,order=26"`
 }
 
 type OtherPayerAmountPaid struct {

--- a/pkg/ncpdp/request/requestSegment/facility.go
+++ b/pkg/ncpdp/request/requestSegment/facility.go
@@ -7,15 +7,19 @@ import (
 
 type Facility struct {
 	SegmentId     ncpdp.SegmentId
-	Id            *string `field:"code=8C,order=2"`
-	Name          *string `field:"code=3Q,order=3"`
+	IdQualifier   *string `field:"code=3Z,order=2"`
+	Id            *string `field:"code=8C,order=3"`
+	Name          *string `field:"code=3Q,order=4"`
 	Address       FacilityAddress
 	DynamicFields []dynamic.DynamicStruct `field:"code=dynamic"`
 }
 
 type FacilityAddress struct {
-	Street *string `field:"code=3U,order=4"`
-	City   *string `field:"code=5J,order=5"`
-	State  *string `field:"code=3V,order=6"`
-	Zip    *string `field:"code=6D,order=7"`
+	Street      *string `field:"code=3U,order=5"`
+	StreetLine1 *string `field:"code=7M,order=6"`
+	StreetLine2 *string `field:"code=7N,order=7"`
+	City        *string `field:"code=5J,order=8"`
+	State       *string `field:"code=3V,order=9"`
+	Zip         *string `field:"code=6D,order=10"`
+	CountryCode *string `field:"code=1X,order=11"`
 }

--- a/pkg/ncpdp/request/requestSegment/intermediary.go
+++ b/pkg/ncpdp/request/requestSegment/intermediary.go
@@ -1,0 +1,24 @@
+package requestsegment
+
+import (
+	"github.com/transactrx/NCPDPSerDe/pkg/dynamic"
+	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp"
+)
+
+type Intermediary struct {
+	SegmentId ncpdp.SegmentId
+
+	IdCount *int `field:"code=8G,order=2"`
+	Ids     []IntermediaryId
+
+	DynamicFields []dynamic.DynamicStruct `field:"code=dynamic"`
+}
+
+type IntermediaryId struct {
+	TypeCode             *string `field:"code=8H,order=3"`
+	TypeEntity           *string `field:"code=8J,order=4"`
+	Qualifier            *string `field:"code=8K,order=5"`
+	Id                   *string `field:"code=8M,order=6"`
+	StateProvinceAddress *string `field:"code=8N,order=7"`
+	CountryCode          *string `field:"code=8U,order=8"`
+}

--- a/pkg/ncpdp/request/requestSegment/lastKnown4Rx.go
+++ b/pkg/ncpdp/request/requestSegment/lastKnown4Rx.go
@@ -1,0 +1,19 @@
+package requestsegment
+
+import (
+	"github.com/transactrx/NCPDPSerDe/pkg/dynamic"
+	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp"
+)
+
+type LastKnown4Rx struct {
+	SegmentId ncpdp.SegmentId
+
+	IinNumber              *string `field:"code=3E,order=2"`
+	ProcessorControlNumber *string `field:"code=3F,order=3"`
+	GroupId                *string `field:"code=3G,order=4"`
+	CardholderId           *string `field:"code=3H,order=5"`
+	YearOfLastPaidClaim    *string `field:"code=3J,order=6"`
+	MonthOfLastPaidClaim   *string `field:"code=3K,order=7"`
+
+	DynamicFields []dynamic.DynamicStruct `field:"code=dynamic"`
+}

--- a/pkg/ncpdp/request/requestSegment/nTransactionPayerIdentification.go
+++ b/pkg/ncpdp/request/requestSegment/nTransactionPayerIdentification.go
@@ -1,0 +1,21 @@
+package requestsegment
+
+import (
+	"github.com/transactrx/NCPDPSerDe/pkg/dynamic"
+	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp"
+)
+
+type NTransactionPayerIdentification struct {
+	SegmentId ncpdp.SegmentId
+
+	PayerIin                    *string `field:"code=9Y,order=2"`
+	PayerProcessorControlNumber *string `field:"code=9Z,order=3"`
+	PayerCardholderId           *string `field:"code=AA,order=4"`
+	PayerGroupId                *string `field:"code=AB,order=5"`
+	PayerAdjudicatedProgramType *string `field:"code=9U,order=6"`
+	TransactionSourceType       *string `field:"code=AC,order=7"`
+	TransactionReconciliationId *string `field:"code=AD,order=8"`
+	TransactionReferenceNumber  *string `field:"code=K5,order=9"`
+
+	DynamicFields []dynamic.DynamicStruct `field:"code=dynamic"`
+}

--- a/pkg/ncpdp/request/requestSegment/patient.go
+++ b/pkg/ncpdp/request/requestSegment/patient.go
@@ -8,27 +8,46 @@ import (
 )
 
 type Patient struct {
-	SegmentId      ncpdp.SegmentId
-	IdQualifier    *string    `field:"code=CX,order=2"`
-	Id             *string    `field:"code=CY,order=3"`
-	BirthDate      *time.Time `field:"code=C4,format=YYYYMMdd,order=4"`
-	GenderCode     *string    `field:"code=C5,order=5"`
-	FirstName      *string    `field:"code=CA,order=6"`
-	LastName       *string    `field:"code=CB,order=7"`
-	Address        PatientAddress
-	Phone          *string                 `field:"code=CQ,order=12"`
-	PlaceOfService *string                 `field:"code=C7,order=13"`
-	EmployerId     *string                 `field:"code=CZ,order=14"`
-	SmokerCode     *string                 `field:"code=1C,order=15"`
-	Pregnant       *string                 `field:"code=2C,order=16"`
-	Email          *string                 `field:"code=HN,order=17"`
-	Residence      *string                 `field:"code=4X,order=18"`
-	DynamicFields  []dynamic.DynamicStruct `field:"code=dynamic"`
+	SegmentId              ncpdp.SegmentId
+	IdCount                *int    `field:"code=RR,order=2"`
+	IdQualifier            *string `field:"code=CX,order=3"`
+	Id                     *string `field:"code=CY,order=4"`
+	// Ids captures every CX/CY occurrence when the F6 patient ID repeats; the
+	// scalar IdQualifier/Id fields are kept for D0 backward compatibility.
+	Ids                    []PatientId
+	BirthDate              *time.Time `field:"code=C4,format=YYYYMMdd,order=5"`
+	GenderCode             *string    `field:"code=C5,order=6"`
+	FirstName              *string    `field:"code=CA,order=7"`
+	MiddleName             *string    `field:"code=0C,order=8"`
+	LastName               *string    `field:"code=CB,order=9"`
+	NameSuffix             *string    `field:"code=0E,order=10"`
+	NamePrefix             *string    `field:"code=0D,order=11"`
+	Address                PatientAddress
+	Phone                  *string                 `field:"code=CQ,order=19"`
+	PlaceOfService         *string                 `field:"code=C7,order=20"`
+	EmployerId             *string                 `field:"code=CZ,order=21"`
+	SmokerCode             *string                 `field:"code=1C,order=22"`
+	Pregnant               *string                 `field:"code=2C,order=23"`
+	Email                  *string                 `field:"code=HN,order=24"`
+	Residence              *string                 `field:"code=4X,order=25"`
+	IdAssociatedState      *string                 `field:"code=YR,order=26"`
+	IdAssociatedCountry    *string                 `field:"code=1Y,order=27"`
+	VeterinaryUseIndicator *string                 `field:"code=1R,order=28"`
+	Species                *string                 `field:"code=S8,order=29"`
+	DynamicFields          []dynamic.DynamicStruct `field:"code=dynamic"`
+}
+
+type PatientId struct {
+	Qualifier *string `field:"code=CX,order=3"`
+	Id        *string `field:"code=CY,order=4"`
 }
 
 type PatientAddress struct {
-	Street *string `field:"code=CM,order=8"`
-	City   *string `field:"code=CN,order=9"`
-	State  *string `field:"code=CO,order=10"`
-	Zip    *string `field:"code=CP,order=11"`
+	Street      *string `field:"code=CM,order=12"`
+	StreetLine1 *string `field:"code=7A,order=13"`
+	StreetLine2 *string `field:"code=7B,order=14"`
+	City        *string `field:"code=CN,order=15"`
+	State       *string `field:"code=CO,order=16"`
+	Zip         *string `field:"code=CP,order=17"`
+	CountryCode *string `field:"code=1K,order=18"`
 }

--- a/pkg/ncpdp/request/requestSegment/pharmacyProvider.go
+++ b/pkg/ncpdp/request/requestSegment/pharmacyProvider.go
@@ -9,5 +9,7 @@ type PharmacyProvider struct {
 	SegmentId     ncpdp.SegmentId
 	IdQualifier   *string                 `field:"code=EY,order=2"`
 	Id            *string                 `field:"code=E9,order=3"`
+	FirstName     *string                 `field:"code=4A,order=4"`
+	LastName      *string                 `field:"code=4M,order=5"`
 	DynamicFields []dynamic.DynamicStruct `field:"code=dynamic"`
 }

--- a/pkg/ncpdp/request/requestSegment/prescriber.go
+++ b/pkg/ncpdp/request/requestSegment/prescriber.go
@@ -14,6 +14,13 @@ type Prescriber struct {
 	Phone               *string `field:"code=PM,order=5"`
 	Address             PrescriberAddress
 	PrimaryCareProvider PrimaryCareProvider
+	IdAssociatedState   *string                 `field:"code=ZK,order=14"`
+	IdAssociatedCountry *string                 `field:"code=3B,order=15"`
+	PhoneExtension      *string                 `field:"code=7T,order=16"`
+	MiddleName          *string                 `field:"code=0F,order=17"`
+	AlternateId         PrescriberAlternateId
+	DeaNumber           *string                 `field:"code=KV,order=25"`
+	PlaceOfService      *string                 `field:"code=RG,order=26"`
 	DynamicFields       []dynamic.DynamicStruct `field:"code=dynamic"`
 }
 
@@ -24,8 +31,18 @@ type PrimaryCareProvider struct {
 }
 
 type PrescriberAddress struct {
-	Street *string `field:"code=2K,order=10"`
-	City   *string `field:"code=2M,order=11"`
-	State  *string `field:"code=2N,order=12"`
-	Zip    *string `field:"code=2P,order=13"`
+	Street      *string `field:"code=2K,order=10"`
+	City        *string `field:"code=2M,order=11"`
+	State       *string `field:"code=2N,order=12"`
+	Zip         *string `field:"code=2P,order=13"`
+	StreetLine1 *string `field:"code=7U,order=18"`
+	StreetLine2 *string `field:"code=7V,order=19"`
+	CountryCode *string `field:"code=3C,order=20"`
+}
+
+type PrescriberAlternateId struct {
+	Qualifier         *string `field:"code=ZM,order=21"`
+	Id                *string `field:"code=ZP,order=22"`
+	AssociatedState   *string `field:"code=ZQ,order=23"`
+	AssociatedCountry *string `field:"code=3A,order=24"`
 }

--- a/pkg/ncpdp/request/requestSegment/pricing.go
+++ b/pkg/ncpdp/request/requestSegment/pricing.go
@@ -22,7 +22,14 @@ type Pricing struct {
 	GrossAmountDue                    *float64                `field:"code=DU,decimalPlaces=2,overpunch=true,order=15"`
 	BasisOfCostDetermination          *string                 `field:"code=DN,order=16"`
 	MedicaidPaidAmount                *float64                `field:"code=N3,decimalPlaces=2,overpunch=true,order=17"`
+	RegulatoryFeeCount                *int `field:"code=RK,order=18"`
+	RegulatoryFees                    []RegulatoryFeeType
+	SubrogationAmountRequested        *float64                `field:"code=KX,decimalPlaces=2,overpunch=true,order=20"`
 	DynamicFields                     []dynamic.DynamicStruct `field:"code=dynamic"`
+}
+
+type RegulatoryFeeType struct {
+	TypeCode *string `field:"code=RL,order=19"`
 }
 
 type OtherAmountClaimSubmitted struct {

--- a/pkg/ncpdp/request/requestSegment/priorAuthorization.go
+++ b/pkg/ncpdp/request/requestSegment/priorAuthorization.go
@@ -27,8 +27,11 @@ type AuthorizedRepresentative struct {
 }
 
 type AuthorizedRepresentativeAddress struct {
-	Street *string `field:"code=PG,order=8"`
-	City   *string `field:"code=PH,order=9"`
-	State  *string `field:"code=PJ,order=10"`
-	Zip    *string `field:"code=PK,order=11"`
+	Street      *string `field:"code=PG,order=8"`
+	StreetLine1 *string `field:"code=7D,order=15"`
+	StreetLine2 *string `field:"code=8B,order=16"`
+	City        *string `field:"code=PH,order=9"`
+	State       *string `field:"code=PJ,order=10"`
+	Zip         *string `field:"code=PK,order=11"`
+	CountryCode *string `field:"code=1U,order=17"`
 }

--- a/pkg/ncpdp/request/requestSegment/workersCompensation.go
+++ b/pkg/ncpdp/request/requestSegment/workersCompensation.go
@@ -20,17 +20,23 @@ type WorkersCompensation struct {
 }
 
 type EmployerAddress struct {
-	Street *string `field:"code=CG,order=4"`
-	City   *string `field:"code=CH,order=5"`
-	State  *string `field:"code=CI,order=6"`
-	Zip    *string `field:"code=CJ,order=7"`
+	Street      *string `field:"code=CG,order=4"`
+	StreetLine1 *string `field:"code=8D,order=22"`
+	StreetLine2 *string `field:"code=7G,order=23"`
+	City        *string `field:"code=CH,order=5"`
+	State       *string `field:"code=CI,order=6"`
+	Zip         *string `field:"code=CJ,order=7"`
+	CountryCode *string `field:"code=1V,order=24"`
 }
 
 type Employer struct {
-	Name        *string `field:"code=CF,order=3"`
-	Address     EmployerAddress
-	Phone       *string `field:"code=CK,order=8"`
-	ContactName *string `field:"code=CL,order=9"`
+	Name             *string `field:"code=CF,order=3"`
+	Address          EmployerAddress
+	Phone            *string `field:"code=CK,order=8"`
+	PhoneExtension   *string `field:"code=7K,order=25"`
+	ContactName      *string `field:"code=CL,order=9"`
+	ContactFirstName *string `field:"code=7H,order=26"`
+	ContactLastName  *string `field:"code=7J,order=27"`
 }
 
 type PayTo struct {
@@ -41,10 +47,13 @@ type PayTo struct {
 }
 
 type PayToAddress struct {
-	Street *string `field:"code=TV,order=16"`
-	City   *string `field:"code=TW,order=17"`
-	State  *string `field:"code=TX,order=18"`
-	Zip    *string `field:"code=TY,order=19"`
+	Street      *string `field:"code=TV,order=16"`
+	StreetLine1 *string `field:"code=7R,order=28"`
+	StreetLine2 *string `field:"code=7S,order=29"`
+	City        *string `field:"code=TW,order=17"`
+	State       *string `field:"code=TX,order=18"`
+	Zip         *string `field:"code=TY,order=19"`
+	CountryCode *string `field:"code=1Z,order=30"`
 }
 
 type GenericEquivalentProduct struct {

--- a/pkg/ncpdp/request/serviceBilling.go
+++ b/pkg/ncpdp/request/serviceBilling.go
@@ -32,6 +32,7 @@ type ServiceBillingRecord struct {
 	AdditionalDocumentation requestsegment.AdditionalDocumentation `segment:"code=AM14,order=9"`
 	Facility                requestsegment.Facility                `segment:"code=AM15,order=10"`
 	Narrative               requestsegment.Narrative               `segment:"code=AM16,order=11"`
+	Intermediary            requestsegment.Intermediary            `segment:"code=AM19,order=12"`
 	DataCollection          requestsegment.DataCollection          `segment:"code=AMXX,order=99"`
 	DynamicSegments         []dynamic.DynamicStruct                `segment:"code=dynamic,order=100"`
 }

--- a/pkg/ncpdp/request/serviceRebill.go
+++ b/pkg/ncpdp/request/serviceRebill.go
@@ -32,6 +32,7 @@ type ServiceRebillRecord struct {
 	AdditionalDocumentation requestsegment.AdditionalDocumentation `segment:"code=AM14,order=9"`
 	Facility                requestsegment.Facility                `segment:"code=AM15,order=10"`
 	Narrative               requestsegment.Narrative               `segment:"code=AM16,order=11"`
+	Intermediary            requestsegment.Intermediary            `segment:"code=AM19,order=12"`
 	DataCollection          requestsegment.DataCollection          `segment:"code=AMXX,order=99"`
 	DynamicSegments         []dynamic.DynamicStruct                `segment:"code=dynamic,order=100"`
 }

--- a/pkg/ncpdp/response/billing.go
+++ b/pkg/ncpdp/response/billing.go
@@ -27,8 +27,11 @@ type BillingRecord struct {
 	Pricing                responsesegment.Pricing                `segment:"code=AM23,order=3"`
 	Dur                    responsesegment.Dur                    `segment:"code=AM24,order=4"`
 	PriorAuthorization     responsesegment.PriorAuthorization     `segment:"code=AM26,order=5"`
-	CoordinationOfBenefits responsesegment.CoordinationOfBenefits `segment:"code=AM28,order=6"`
-	DynamicSegments        []dynamic.DynamicStruct                `segment:"code=dynamic,order=100"`
+	CoordinationOfBenefits    responsesegment.CoordinationOfBenefits    `segment:"code=AM28,order=6"`
+	Intermediary              responsesegment.Intermediary              `segment:"code=AM36,order=7"`
+	OtherRelatedBenefitDetail responsesegment.OtherRelatedBenefitDetail `segment:"code=AM39,order=8"`
+	Provider                  responsesegment.Provider                  `segment:"code=AM40,order=9"`
+	DynamicSegments           []dynamic.DynamicStruct                   `segment:"code=dynamic,order=100"`
 
 	//TOOD: Include price update info
 }

--- a/pkg/ncpdp/response/eligibility.go
+++ b/pkg/ncpdp/response/eligibility.go
@@ -23,6 +23,7 @@ type Eligibility struct {
 type EligibilityRecord struct {
 	Raw                    string                                 `field:"code=rawgroup"`
 	Status                 responsesegment.Status                 `segment:"code=AM21,order=1"`
-	CoordinationOfBenefits responsesegment.CoordinationOfBenefits `segment:"code=AM28,order=2"`
-	DynamicSegments        []dynamic.DynamicStruct                `segment:"code=dynamic,order=100"`
+	CoordinationOfBenefits    responsesegment.CoordinationOfBenefits    `segment:"code=AM28,order=2"`
+	OtherRelatedBenefitDetail responsesegment.OtherRelatedBenefitDetail `segment:"code=AM39,order=3"`
+	DynamicSegments           []dynamic.DynamicStruct                   `segment:"code=dynamic,order=100"`
 }

--- a/pkg/ncpdp/response/predeterminationOfBenefits.go
+++ b/pkg/ncpdp/response/predeterminationOfBenefits.go
@@ -26,6 +26,8 @@ type PredeterminationOfBenefitsRecord struct {
 	Claim                  responsesegment.Claim                  `segment:"code=AM22,order=2"`
 	Pricing                responsesegment.Pricing                `segment:"code=AM23,order=3"`
 	Dur                    responsesegment.Dur                    `segment:"code=AM24,order=4"`
-	CoordinationOfBenefits responsesegment.CoordinationOfBenefits `segment:"code=AM28,order=5"`
-	DynamicSegments        []dynamic.DynamicStruct                `segment:"code=dynamic,order=100"`
+	CoordinationOfBenefits    responsesegment.CoordinationOfBenefits    `segment:"code=AM28,order=5"`
+	OtherRelatedBenefitDetail responsesegment.OtherRelatedBenefitDetail `segment:"code=AM39,order=6"`
+	Provider                  responsesegment.Provider                  `segment:"code=AM40,order=7"`
+	DynamicSegments           []dynamic.DynamicStruct                   `segment:"code=dynamic,order=100"`
 }

--- a/pkg/ncpdp/response/priorAuthorization.go
+++ b/pkg/ncpdp/response/priorAuthorization.go
@@ -27,8 +27,11 @@ type PriorAuthorizationRecord struct {
 	Pricing                responsesegment.Pricing                `segment:"code=AM23,order=3"`
 	Dur                    responsesegment.Dur                    `segment:"code=AM24,order=5"`
 	PriorAuthorization     responsesegment.PriorAuthorization     `segment:"code=AM26,order=4"`
-	CoordinationOfBenefits responsesegment.CoordinationOfBenefits `segment:"code=AM28,order=6"`
-	DynamicSegments        []dynamic.DynamicStruct                `segment:"code=dynamic,order=100"`
+	CoordinationOfBenefits    responsesegment.CoordinationOfBenefits    `segment:"code=AM28,order=6"`
+	Intermediary              responsesegment.Intermediary              `segment:"code=AM36,order=7"`
+	OtherRelatedBenefitDetail responsesegment.OtherRelatedBenefitDetail `segment:"code=AM39,order=8"`
+	Provider                  responsesegment.Provider                  `segment:"code=AM40,order=9"`
+	DynamicSegments           []dynamic.DynamicStruct                   `segment:"code=dynamic,order=100"`
 
 	//TOOD: Include price update info
 }

--- a/pkg/ncpdp/response/priorAuthorizationInquiry.go
+++ b/pkg/ncpdp/response/priorAuthorizationInquiry.go
@@ -27,8 +27,10 @@ type PriorAuthorizationInquiryRecord struct {
 	Pricing                responsesegment.Pricing                `segment:"code=AM23,order=3"`
 	Dur                    responsesegment.Dur                    `segment:"code=AM24,order=5"`
 	PriorAuthorization     responsesegment.PriorAuthorization     `segment:"code=AM26,order=4"`
-	CoordinationOfBenefits responsesegment.CoordinationOfBenefits `segment:"code=AM28,order=6"`
-	DynamicSegments        []dynamic.DynamicStruct                `segment:"code=dynamic,order=100"`
+	CoordinationOfBenefits    responsesegment.CoordinationOfBenefits    `segment:"code=AM28,order=6"`
+	OtherRelatedBenefitDetail responsesegment.OtherRelatedBenefitDetail `segment:"code=AM39,order=7"`
+	Provider                  responsesegment.Provider                  `segment:"code=AM40,order=8"`
+	DynamicSegments           []dynamic.DynamicStruct                   `segment:"code=dynamic,order=100"`
 
 	//TOOD: Include price update info
 }

--- a/pkg/ncpdp/response/priorAuthorizationRequestOnly.go
+++ b/pkg/ncpdp/response/priorAuthorizationRequestOnly.go
@@ -24,6 +24,7 @@ type PriorAuthorizationRequestOnlyRecord struct {
 	Claim                  responsesegment.Claim                  `segment:"code=AM22,order=2"`
 	PriorAuthorization     responsesegment.PriorAuthorization     `segment:"code=AM26,order=3"`
 	CoordinationOfBenefits responsesegment.CoordinationOfBenefits `segment:"code=AM28,order=4"`
+	Provider               responsesegment.Provider               `segment:"code=AM40,order=5"`
 	DynamicSegments        []dynamic.DynamicStruct                `segment:"code=dynamic,order=100"`
 
 	//TOOD: Include price update info

--- a/pkg/ncpdp/response/rebill.go
+++ b/pkg/ncpdp/response/rebill.go
@@ -27,8 +27,11 @@ type RebillRecord struct {
 	Pricing                responsesegment.Pricing                `segment:"code=AM23,order=3"`
 	Dur                    responsesegment.Dur                    `segment:"code=AM24,order=4"`
 	PriorAuthorization     responsesegment.PriorAuthorization     `segment:"code=AM26,order=5"`
-	CoordinationOfBenefits responsesegment.CoordinationOfBenefits `segment:"code=AM28,order=6"`
-	DynamicSegments        []dynamic.DynamicStruct                `segment:"code=dynamic,order=100"`
+	CoordinationOfBenefits    responsesegment.CoordinationOfBenefits    `segment:"code=AM28,order=6"`
+	Intermediary              responsesegment.Intermediary              `segment:"code=AM36,order=7"`
+	OtherRelatedBenefitDetail responsesegment.OtherRelatedBenefitDetail `segment:"code=AM39,order=8"`
+	Provider                  responsesegment.Provider                  `segment:"code=AM40,order=9"`
+	DynamicSegments           []dynamic.DynamicStruct                   `segment:"code=dynamic,order=100"`
 
 	//TOOD: Include price update info
 }

--- a/pkg/ncpdp/response/responseSegment/claim.go
+++ b/pkg/ncpdp/response/responseSegment/claim.go
@@ -1,6 +1,8 @@
 package responsesegment
 
 import (
+	"time"
+
 	"github.com/transactrx/NCPDPSerDe/pkg/dynamic"
 	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp"
 )
@@ -10,8 +12,33 @@ type Claim struct {
 	PrescriptionServiceReference             PrescriptionServiceReference
 	PreferredProductCount                    *int `field:"code=9F,order=4"`
 	PreferredProducts                        []PreferredProduct
-	MedicaidSubrogationInternalControlNumber *string                 `field:"code=N4,order=10"`
-	DynamicFields                            []dynamic.DynamicStruct `field:"code=dynamic"`
+	MedicaidSubrogationInternalControlNumber *string `field:"code=N4,order=10"`
+
+	PlanBenefitOverrideIndicator  *string `field:"code=RC,order=20"`
+	PlanBenefitOverrideValueCount *int    `field:"code=RD,order=21"`
+	PlanBenefitOverrideValues     []PlanBenefitOverrideValue
+
+	MaximumAgeQualifier              *string    `field:"code=F8,order=23"`
+	MaximumAge                       *int       `field:"code=GA,order=24"`
+	MinimumAgeQualifier              *string    `field:"code=GQ,order=25"`
+	MinimumAge                       *int       `field:"code=GR,order=26"`
+	MinimumAmountQualifier           *string    `field:"code=M2,order=27"`
+	MinimumAmount                    *float64   `field:"code=M1,decimalPlaces=3,order=28"`
+	MaximumAmountQualifier           *string    `field:"code=GC,order=29"`
+	MaximumAmount                    *float64   `field:"code=GB,decimalPlaces=3,order=30"`
+	MaximumAmountTimePeriod          *string    `field:"code=GF,order=31"`
+	MaximumAmountTimePeriodEndDate   *time.Time `field:"code=GH,format=YYYYMMdd,order=32"`
+	MaximumAmountTimePeriodStartDate *time.Time `field:"code=GG,format=YYYYMMdd,order=33"`
+	MaximumAmountTimePeriodUnits     *int       `field:"code=GJ,order=34"`
+	RemainingAmountQualifier         *string    `field:"code=M7,order=35"`
+	RemainingAmount                  *float64   `field:"code=M6,decimalPlaces=3,order=36"`
+
+	BenefitTypeOpportunityCount *int `field:"code=AF,order=37"`
+	BenefitTypeOpportunities    []BenefitTypeOpportunity
+
+	SubrogationRequestorsReconciliationId *string `field:"code=KY,order=39"`
+
+	DynamicFields []dynamic.DynamicStruct `field:"code=dynamic"`
 }
 
 type PrescriptionServiceReference struct {
@@ -25,4 +52,28 @@ type PreferredProduct struct {
 	Incentive          *float64 `field:"code=AS,decimalPlaces=2,overpunch=true,order=7"`
 	CostShareIncentive *float64 `field:"code=AT,decimalPlaces=2,overpunch=true,order=8"`
 	Description        *string  `field:"code=AU,order=9"`
+
+	EffectiveDate   *time.Time `field:"code=ZO,format=YYYYMMdd,order=11"`
+	PlanBenefitTier *string    `field:"code=PV,order=12"`
+	ReasonCode      *string    `field:"code=PZ,order=13"`
+
+	RequiredTherapyIndicatorCount *int `field:"code=P0,order=14"`
+	RequiredTherapyIndicators     []RequiredTherapyIndicator
+
+	RequiredTherapyTimePeriodQualifier *string    `field:"code=P2,order=16"`
+	RequiredTherapyTimePeriodDuration  *string    `field:"code=P3,order=17"`
+	RequiredTherapyTimePeriodStartDate *time.Time `field:"code=P4,format=YYYYMMdd,order=18"`
+	RequiredTherapyTimePeriodEndDate   *time.Time `field:"code=P5,format=YYYYMMdd,order=19"`
+}
+
+type RequiredTherapyIndicator struct {
+	Indicator *string `field:"code=P1,order=15"`
+}
+
+type PlanBenefitOverrideValue struct {
+	Value *string `field:"code=RF,order=22"`
+}
+
+type BenefitTypeOpportunity struct {
+	Opportunity *string `field:"code=AE,order=38"`
 }

--- a/pkg/ncpdp/response/responseSegment/coordinationOfBenefits.go
+++ b/pkg/ncpdp/response/responseSegment/coordinationOfBenefits.go
@@ -26,4 +26,9 @@ type OtherPayer struct {
 	PatientRelationshipCode *string    `field:"code=UW,order=11"`
 	BenefitEffectiveDate    *time.Time `field:"code=UX,format=YYYYMMdd,order=12"`
 	BenefitTerminationDate  *time.Time `field:"code=UY,format=YYYYMMdd,order=13"`
+	RelationshipType        *string    `field:"code=PQ,order=14"`
+	BenefitClassification   *string    `field:"code=P6,order=15"`
+	AdjudicatedProgramType  *string    `field:"code=9T,order=16"`
+	Name                    *string    `field:"code=M5,order=17"`
+	HelpDeskPhoneExtension  *string    `field:"code=7Q,order=18"`
 }

--- a/pkg/ncpdp/response/responseSegment/dur.go
+++ b/pkg/ncpdp/response/responseSegment/dur.go
@@ -26,4 +26,28 @@ type DurItem struct {
 	OtherPrescriberIndicator *string    `field:"code=FX,order=9"`
 	FreeText                 *string    `field:"code=FY,order=10"`
 	AdditionalText           *string    `field:"code=NS,order=11"`
+
+	CoAgentIdQualifier *string `field:"code=J9,order=12"`
+	CoAgentId          *string `field:"code=H6,order=13"`
+	CoAgentDescription *string `field:"code=ZC,order=14"`
+
+	OtherPharmacyIdQualifier *string `field:"code=Z9,order=15"`
+	OtherPharmacyId          *string `field:"code=Z8,order=16"`
+	OtherPharmacyName        *string `field:"code=Z7,order=17"`
+	OtherPharmacyTelephone   *string `field:"code=Z6,order=18"`
+
+	UnitOfMeasureForPreviousDispensedQuantity *string `field:"code=ZA,order=19"`
+
+	OtherPrescriberIdQualifier     *string `field:"code=Z4,order=20"`
+	OtherPrescriberId              *string `field:"code=Z3,order=21"`
+	OtherPrescriberLastName        *string `field:"code=Z5,order=22"`
+	OtherPrescriberTelephoneNumber *string `field:"code=Z2,order=23"`
+
+	CompoundProductIdQualifier *string `field:"code=Z0,order=24"`
+	CompoundProductId          *string `field:"code=Z1,order=25"`
+
+	MaximumDailyDoseQuantity      *float64 `field:"code=YO,decimalPlaces=3,order=26"`
+	MaximumDailyDoseUnitOfMeasure *string  `field:"code=YL,order=27"`
+	MinimumDailyDoseQuantity      *float64 `field:"code=YJ,decimalPlaces=3,order=28"`
+	MinimumDailyDoseUnitOfMeasure *string  `field:"code=YI,order=29"`
 }

--- a/pkg/ncpdp/response/responseSegment/insurance.go
+++ b/pkg/ncpdp/response/responseSegment/insurance.go
@@ -10,18 +10,22 @@ type Insurance struct {
 	GroupId                *string `field:"code=C1,order=2"`
 	PlanId                 *string `field:"code=FO,order=3"`
 	NetworkReimbursementId *string `field:"code=2F,order=4"`
+	PayerIdCount           *int `field:"code=KR,order=5"`
 	Payer                  Payer
+	// Payers captures every J7/J8 occurrence when the F6 payer ID repeats; the
+	// singular Payer struct is kept for D0 backward compatibility.
+	Payers                 []Payer
 	Medicaid               Medicaid
-	CardholderId           *string                 `field:"code=C2,order=9"`
+	CardholderId           *string                 `field:"code=C2,order=10"`
 	DynamicFields          []dynamic.DynamicStruct `field:"code=dynamic"`
 }
 
 type Medicaid struct {
-	Id           *string `field:"code=N5,order=7"`
-	AgencyNumber *string `field:"code=N6,order=8"`
+	Id           *string `field:"code=N5,order=8"`
+	AgencyNumber *string `field:"code=N6,order=9"`
 }
 
 type Payer struct {
-	Qualifier *string `field:"code=J7,order=5"`
-	Id        *string `field:"code=J8,order=6"`
+	Qualifier *string `field:"code=J7,order=6"`
+	Id        *string `field:"code=J8,order=7"`
 }

--- a/pkg/ncpdp/response/responseSegment/insuranceAdditionalInformation.go
+++ b/pkg/ncpdp/response/responseSegment/insuranceAdditionalInformation.go
@@ -12,6 +12,7 @@ type InsuranceAdditionalInformation struct {
 	MedicarePartD  MedicarePartD
 	ContractNumber *string `field:"code=U1,order=4"`
 	FormularyId    *string `field:"code=FF,order=5"`
+	PlanName       *string `field:"code=96,order=9"`
 }
 
 type MedicarePartD struct {

--- a/pkg/ncpdp/response/responseSegment/intermediary.go
+++ b/pkg/ncpdp/response/responseSegment/intermediary.go
@@ -1,0 +1,43 @@
+package responsesegment
+
+import (
+	"github.com/transactrx/NCPDPSerDe/pkg/dynamic"
+	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp"
+)
+
+type Intermediary struct {
+	SegmentId ncpdp.SegmentId
+
+	AuthorizationCount *int `field:"code=8R,order=2"`
+	Authorizations     []IntermediaryAuthorization
+
+	Messages []IntermediaryMessage
+
+	HelpDeskSupportTypeCount *int `field:"code=KC,order=6"`
+	HelpDeskSupportTypes     []IntermediaryHelpDeskSupportType
+
+	HelpDeskBusinessUnitTypeCount *int `field:"code=G9,order=8"`
+	HelpDeskBusinessUnits         []IntermediaryHelpDeskBusinessUnit
+
+	DynamicFields []dynamic.DynamicStruct `field:"code=dynamic"`
+}
+
+type IntermediaryAuthorization struct {
+	TypeId *string `field:"code=8S,order=3"`
+	Id     *string `field:"code=8T,order=4"`
+}
+
+type IntermediaryMessage struct {
+	Message *string `field:"code=8Q,order=5"`
+}
+
+type IntermediaryHelpDeskSupportType struct {
+	Type *string `field:"code=KB,order=7"`
+}
+
+type IntermediaryHelpDeskBusinessUnit struct {
+	Type                        *string `field:"code=G8,order=9"`
+	ContactInformationQualifier *string `field:"code=KA,order=10"`
+	ContactInformation          *string `field:"code=JP,order=11"`
+	ContactInformationExtension *string `field:"code=JR,order=12"`
+}

--- a/pkg/ncpdp/response/responseSegment/otherRelatedBenefitDetail.go
+++ b/pkg/ncpdp/response/responseSegment/otherRelatedBenefitDetail.go
@@ -1,0 +1,56 @@
+package responsesegment
+
+import (
+	"time"
+
+	"github.com/transactrx/NCPDPSerDe/pkg/dynamic"
+	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp"
+)
+
+type OtherRelatedBenefitDetail struct {
+	SegmentId ncpdp.SegmentId
+
+	PlanType                     *string    `field:"code=KS,order=2"`
+	LisLevel                     *string    `field:"code=KF,order=3"`
+	LisEffectiveDate             *time.Time `field:"code=KD,format=YYYYMMdd,order=4"`
+	LisTerminationDate           *time.Time `field:"code=KG,format=YYYYMMdd,order=5"`
+	DisabilityEffectiveDate      *time.Time `field:"code=AH,format=YYYYMMdd,order=6"`
+	EsrdIndicator                *string    `field:"code=A5,order=7"`
+	EsrdEffectiveDate            *time.Time `field:"code=AJ,format=YYYYMMdd,order=8"`
+	EsrdTerminationDate          *time.Time `field:"code=A6,format=YYYYMMdd,order=9"`
+	HospiceEffectiveDate         *time.Time `field:"code=G4,format=YYYYMMdd,order=10"`
+	HospiceTerminationDate       *time.Time `field:"code=G7,format=YYYYMMdd,order=11"`
+	HospiceProviderNumber        *string    `field:"code=G6,order=12"`
+	HospiceFacilityName          *string    `field:"code=G5,order=13"`
+	HospiceTelephoneNumber       *string    `field:"code=A8,order=14"`
+	InstitutionalIndicator       *string    `field:"code=BJ,order=15"`
+	InstitutionalEffectiveDate   *time.Time `field:"code=BK,format=YYYYMMdd,order=16"`
+	InstitutionalTerminationDate *time.Time `field:"code=GD,format=YYYYMMdd,order=17"`
+
+	OtherBenefitCount *int `field:"code=M8,order=18"`
+	OtherBenefits     []OtherBenefit
+
+	OtherBenefitDetailInformationCount *int `field:"code=N8,order=26"`
+	OtherBenefitDetailInformation      []OtherBenefitDetailInformation
+
+	DynamicFields []dynamic.DynamicStruct `field:"code=dynamic"`
+}
+
+type OtherBenefit struct {
+	TypeCode                *string    `field:"code=PN,order=19"`
+	EffectiveDate           *time.Time `field:"code=MZ,format=YYYYMMdd,order=20"`
+	TerminationDate         *time.Time `field:"code=NN,format=YYYYMMdd,order=21"`
+	StateProvinceAddress    *string    `field:"code=TA,order=22"`
+	TypeId                  *string    `field:"code=N9,order=23"`
+	FacilityName            *string    `field:"code=N1,order=24"`
+	FacilityTelephoneNumber *string    `field:"code=N7,order=25"`
+}
+
+type OtherBenefitDetailInformation struct {
+	Indicator               *string    `field:"code=MS,order=27"`
+	EffectiveDate           *time.Time `field:"code=MM,format=YYYYMMdd,order=28"`
+	TerminationDate         *time.Time `field:"code=MX,format=YYYYMMdd,order=29"`
+	ProviderNumber          *string    `field:"code=MR,order=30"`
+	FacilityName            *string    `field:"code=MN,order=31"`
+	FacilityTelephoneNumber *string    `field:"code=MP,order=32"`
+}

--- a/pkg/ncpdp/response/responseSegment/patient.go
+++ b/pkg/ncpdp/response/responseSegment/patient.go
@@ -8,9 +8,18 @@ import (
 )
 
 type Patient struct {
-	SegmentId     ncpdp.SegmentId
-	FirstName     *string                 `field:"code=CA,order=2"`
-	LastName      *string                 `field:"code=CB,order=3"`
-	BirthDate     *time.Time              `field:"code=C4,format=YYYYMMdd,order=4"`
+	SegmentId ncpdp.SegmentId
+
+	IdCount *int `field:"code=RR,order=2"`
+	Ids     []PatientId
+
+	FirstName     *string                 `field:"code=CA,order=5"`
+	LastName      *string                 `field:"code=CB,order=6"`
+	BirthDate     *time.Time              `field:"code=C4,format=YYYYMMdd,order=7"`
 	DynamicFields []dynamic.DynamicStruct `field:"code=dynamic"`
+}
+
+type PatientId struct {
+	Qualifier *string `field:"code=CX,order=3"`
+	Id        *string `field:"code=CY,order=4"`
 }

--- a/pkg/ncpdp/response/responseSegment/pricing.go
+++ b/pkg/ncpdp/response/responseSegment/pricing.go
@@ -44,9 +44,36 @@ type Pricing struct {
 	AmountAttributedToNonPreferredFormularyProductSelection      *float64                `field:"code=UM,decimalPlaces=2,overpunch=true,order=42"`
 	AmountAttributedToBrandNonPreferredFormularyProductSelection *float64                `field:"code=UN,decimalPlaces=2,overpunch=true,order=43"`
 	AmountAttributedToCoverageGap                                *float64                `field:"code=UP,decimalPlaces=2,overpunch=true,order=44"`
-	IngredientCostContractedReimbursableAmount                   *float64                `field:"code=U8,decimalPlaces=2,overpunch=true,order=45"`
-	DispensingFeeContractedReimbursableAmount                    *float64                `field:"code=U9,decimalPlaces=2,overpunch=true,order=46"`
-	DynamicFields                                                []dynamic.DynamicStruct `field:"code=dynamic"`
+	IngredientCostContractedReimbursableAmount                   *float64 `field:"code=U8,decimalPlaces=2,overpunch=true,order=45"`
+	DispensingFeeContractedReimbursableAmount                    *float64 `field:"code=U9,decimalPlaces=2,overpunch=true,order=46"`
+
+	PatientPayComponentCount *int `field:"code=KP,order=47"`
+	PatientPayComponents     []PatientPayComponent
+
+	RegulatoryFeeCount *int `field:"code=RK,order=50"`
+	RegulatoryFees     []RegulatoryFee
+
+	BenefitStageIndicatorCount *int `field:"code=9W,order=53"`
+	BenefitStageIndicators     []BenefitStageIndicator
+
+	PatientRegulatoryFeeAmount                         *float64 `field:"code=RS,decimalPlaces=2,overpunch=true,order=55"`
+	ProfessionalServiceFeeContractedReimbursableAmount *float64 `field:"code=6G,decimalPlaces=2,overpunch=true,order=56"`
+
+	DynamicFields []dynamic.DynamicStruct `field:"code=dynamic"`
+}
+
+type PatientPayComponent struct {
+	Qualifier *string  `field:"code=KQ,order=48"`
+	Amount    *float64 `field:"code=KN,decimalPlaces=2,overpunch=true,order=49"`
+}
+
+type RegulatoryFee struct {
+	TypeCode        *string `field:"code=RL,order=51"`
+	ExemptIndicator *string `field:"code=RM,order=52"`
+}
+
+type BenefitStageIndicator struct {
+	Indicator *string `field:"code=9X,order=54"`
 }
 
 type OtherAmountPaid struct {

--- a/pkg/ncpdp/response/responseSegment/provider.go
+++ b/pkg/ncpdp/response/responseSegment/provider.go
@@ -1,0 +1,15 @@
+package responsesegment
+
+import (
+	"github.com/transactrx/NCPDPSerDe/pkg/dynamic"
+	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp"
+)
+
+type Provider struct {
+	SegmentId ncpdp.SegmentId
+
+	DataSourceOfInvalidProviderDetermination             *string `field:"code=ZV,order=2"`
+	StateCodeForDataSourceOfInvalidProviderDetermination *string `field:"code=ZZ,order=3"`
+
+	DynamicFields []dynamic.DynamicStruct `field:"code=dynamic"`
+}

--- a/pkg/ncpdp/response/responseSegment/status.go
+++ b/pkg/ncpdp/response/responseSegment/status.go
@@ -3,6 +3,7 @@ package responsesegment
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/transactrx/NCPDPSerDe/pkg/dynamic"
 	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp"
@@ -26,10 +27,33 @@ type Status struct {
 	AdditionalMessageCount     *int `field:"code=UF,order=9"`
 	AdditionalMessages         []AdditionalMessage
 	HelpDeskPhoneNumber        HelpDeskPhoneNumber
-	TransactionReferenceNumber *string                 `field:"code=K5,order=15"`
-	InternalControlNumber      *string                 `field:"code=A7,order=16"`
-	Url                        *string                 `field:"code=MA,order=17"`
-	DynamicFields              []dynamic.DynamicStruct `field:"code=dynamic"`
+	TransactionReferenceNumber *string `field:"code=K5,order=15"`
+	InternalControlNumber      *string `field:"code=A7,order=16"`
+	Url                        *string `field:"code=MA,order=17"`
+
+	ReconciliationId *string `field:"code=34,order=18"`
+
+	HelpDeskSupportTypeCount *int `field:"code=BH,order=19"`
+	HelpDeskSupportTypes     []HelpDeskSupportType
+
+	HelpDeskBusinessUnitTypeCount *int `field:"code=BB,order=21"`
+	HelpDeskBusinessUnits         []HelpDeskBusinessUnit
+
+	HelpDeskContactInformationExtension *string    `field:"code=BD,order=25"`
+	AdjudicatedProgramType              *string    `field:"code=ZR,order=26"`
+	NextAvailableFillDate               *time.Time `field:"code=BT,format=YYYYMMdd,order=27"`
+
+	DynamicFields []dynamic.DynamicStruct `field:"code=dynamic"`
+}
+
+type HelpDeskSupportType struct {
+	Type *string `field:"code=BG,order=20"`
+}
+
+type HelpDeskBusinessUnit struct {
+	Type                        *string `field:"code=BA,order=22"`
+	ContactInformationQualifier *string `field:"code=BF,order=23"`
+	ContactInformation          *string `field:"code=BC,order=24"`
 }
 
 type RejectCode struct {

--- a/pkg/ncpdp/response/serviceBilling.go
+++ b/pkg/ncpdp/response/serviceBilling.go
@@ -27,6 +27,9 @@ type ServiceBillingRecord struct {
 	Pricing                responsesegment.Pricing                `segment:"code=AM23,order=3"`
 	Dur                    responsesegment.Dur                    `segment:"code=AM24,order=4"`
 	PriorAuthorization     responsesegment.PriorAuthorization     `segment:"code=AM26,order=5"`
-	CoordinationOfBenefits responsesegment.CoordinationOfBenefits `segment:"code=AM28,order=6"`
-	DynamicSegments        []dynamic.DynamicStruct                `segment:"code=dynamic,order=100"`
+	CoordinationOfBenefits    responsesegment.CoordinationOfBenefits    `segment:"code=AM28,order=6"`
+	Intermediary              responsesegment.Intermediary              `segment:"code=AM36,order=7"`
+	OtherRelatedBenefitDetail responsesegment.OtherRelatedBenefitDetail `segment:"code=AM39,order=8"`
+	Provider                  responsesegment.Provider                  `segment:"code=AM40,order=9"`
+	DynamicSegments           []dynamic.DynamicStruct                   `segment:"code=dynamic,order=100"`
 }

--- a/pkg/ncpdp/response/serviceRebill.go
+++ b/pkg/ncpdp/response/serviceRebill.go
@@ -27,8 +27,11 @@ type ServiceRebillRecord struct {
 	Pricing                responsesegment.Pricing                `segment:"code=AM23,order=3"`
 	Dur                    responsesegment.Dur                    `segment:"code=AM24,order=4"`
 	PriorAuthorization     responsesegment.PriorAuthorization     `segment:"code=AM26,order=5"`
-	CoordinationOfBenefits responsesegment.CoordinationOfBenefits `segment:"code=AM28,order=6"`
-	DynamicSegments        []dynamic.DynamicStruct                `segment:"code=dynamic,order=100"`
+	CoordinationOfBenefits    responsesegment.CoordinationOfBenefits    `segment:"code=AM28,order=6"`
+	Intermediary              responsesegment.Intermediary              `segment:"code=AM36,order=7"`
+	OtherRelatedBenefitDetail responsesegment.OtherRelatedBenefitDetail `segment:"code=AM39,order=8"`
+	Provider                  responsesegment.Provider                  `segment:"code=AM40,order=9"`
+	DynamicSegments           []dynamic.DynamicStruct                   `segment:"code=dynamic,order=100"`
 
 	//TOOD: Include price update info
 }

--- a/pkg/ncpdp/schemas/ncpdp-schemas.json
+++ b/pkg/ncpdp/schemas/ncpdp-schemas.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://transactrx.com/ncpdp/schemas/ncpdp-schemas.json",
-  "title": "NCPDP D.0 Transaction Schemas",
-  "description": "JSON Schema definitions for NCPDP D.0 request and response transactions",
+  "title": "NCPDP D.0/F6 Transaction Schemas",
+  "description": "JSON Schema definitions for NCPDP D.0 and F6 request and response transactions",
 
   "$defs": {
     "RequestHeader": {
@@ -14,8 +14,8 @@
         "Value": {
           "type": "object",
           "properties": {
-            "Bin": { "type": "string", "maxLength": 6, "description": "BIN Number (6 characters)" },
-            "Version": { "type": "string", "maxLength": 2, "description": "Version/Release Number (D0)" },
+            "Bin": { "type": "string", "maxLength": 8, "description": "BIN Number (D.0, 6 characters) or IIN (F6, 8 characters)" },
+            "Version": { "type": "string", "maxLength": 2, "description": "Version/Release Number (D0 or F6)" },
             "TransactionCode": { "type": "string", "maxLength": 2, "description": "Transaction Code (B1, B2, B3, E1, N1, N2, P1, P2, P3, P4, S1, S2, S3, C1, C2, C3)" },
             "Pcn": { "type": "string", "maxLength": 10, "description": "Processor Control Number" },
             "RecordCount": { "type": "integer", "minimum": 1, "maximum": 4, "description": "Transaction Count (1-4)" },
@@ -38,7 +38,7 @@
         "Value": {
           "type": "object",
           "properties": {
-            "Version": { "type": "string", "maxLength": 2, "description": "Version/Release Number (D0)" },
+            "Version": { "type": "string", "maxLength": 2, "description": "Version/Release Number (D0 or F6)" },
             "TransactionCode": { "type": "string", "maxLength": 2, "description": "Transaction Code" },
             "RecordCount": { "type": "integer", "minimum": 1, "maximum": 4, "description": "Transaction Count" },
             "Status": { "type": "string", "maxLength": 1, "description": "Header Response Status (A=Accepted, R=Rejected)" },
@@ -114,19 +114,37 @@
       "description": "Patient Segment (AM01) - Request",
       "properties": {
         "SegmentId": { "$ref": "#/$defs/SegmentId" },
+        "IdCount": { "type": ["integer", "null"], "description": "Patient ID Count (RR) - F6" },
         "IdQualifier": { "type": ["string", "null"], "description": "Patient ID Qualifier (CX)" },
         "Id": { "type": ["string", "null"], "description": "Patient ID (CY)" },
+        "Ids": {
+          "type": ["array", "null"],
+          "description": "Patient IDs - every CX/CY occurrence when repeating; IdQualifier/Id scalars retain a single occurrence for backward compatibility - F6",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Qualifier": { "type": ["string", "null"], "description": "Patient ID Qualifier (CX)" },
+              "Id": { "type": ["string", "null"], "description": "Patient ID (CY)" }
+            }
+          }
+        },
         "BirthDate": { "type": ["string", "null"], "format": "date", "description": "Date of Birth (C4) - YYYYMMDD" },
         "GenderCode": { "type": ["string", "null"], "description": "Patient Gender Code (C5) - 1=Male, 2=Female" },
         "FirstName": { "type": ["string", "null"], "description": "Patient First Name (CA)" },
+        "MiddleName": { "type": ["string", "null"], "description": "Patient Middle Name (0C) - F6" },
         "LastName": { "type": ["string", "null"], "description": "Patient Last Name (CB)" },
+        "NameSuffix": { "type": ["string", "null"], "description": "Patient Name Suffix (0E) - F6" },
+        "NamePrefix": { "type": ["string", "null"], "description": "Patient Name Prefix (0D) - F6" },
         "Address": {
           "type": "object",
           "properties": {
             "Street": { "type": ["string", "null"], "description": "Patient Street Address (CM)" },
+            "StreetLine1": { "type": ["string", "null"], "description": "Patient Street Address Line 1 (7A) - F6" },
+            "StreetLine2": { "type": ["string", "null"], "description": "Patient Street Address Line 2 (7B) - F6" },
             "City": { "type": ["string", "null"], "description": "Patient City Address (CN)" },
             "State": { "type": ["string", "null"], "description": "Patient State/Province Address (CO)" },
-            "Zip": { "type": ["string", "null"], "description": "Patient Zip/Postal Zone (CP)" }
+            "Zip": { "type": ["string", "null"], "description": "Patient Zip/Postal Zone (CP)" },
+            "CountryCode": { "type": ["string", "null"], "description": "Patient Country Code (1K) - F6" }
           }
         },
         "Phone": { "type": ["string", "null"], "description": "Patient Phone Number (CQ)" },
@@ -136,6 +154,10 @@
         "Pregnant": { "type": ["string", "null"], "description": "Pregnancy Indicator (2C)" },
         "Email": { "type": ["string", "null"], "description": "Patient E-Mail Address (HN)" },
         "Residence": { "type": ["string", "null"], "description": "Patient Residence (4X)" },
+        "IdAssociatedState": { "type": ["string", "null"], "description": "Patient ID Associated State/Province Address (YR) - F6" },
+        "IdAssociatedCountry": { "type": ["string", "null"], "description": "Patient ID Associated Country Code (1Y) - F6" },
+        "VeterinaryUseIndicator": { "type": ["string", "null"], "description": "Veterinary Use Indicator (1R) - F6" },
+        "Species": { "type": ["string", "null"], "description": "Species (S8) - F6" },
         "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
       }
     },
@@ -163,7 +185,11 @@
           "type": "object",
           "properties": {
             "Number": { "type": ["string", "null"], "description": "Associated Prescription/Service Reference Number (EN)" },
-            "Date": { "type": ["string", "null"], "format": "date", "description": "Associated Prescription/Service Date (EP)" }
+            "Date": { "type": ["string", "null"], "format": "date", "description": "Associated Prescription/Service Date (EP)" },
+            "ReferenceNumberQualifier": { "type": ["string", "null"], "description": "Associated Prescription/Service Reference Number Qualifier (XZ) - F6" },
+            "ProviderIdQualifier": { "type": ["string", "null"], "description": "Associated Prescription/Service Provider ID Qualifier (XX) - F6" },
+            "ProviderId": { "type": ["string", "null"], "description": "Associated Prescription/Service Provider ID (XY) - F6" },
+            "FillNumber": { "type": ["string", "null"], "description": "Associated Prescription/Service Fill Number (X0) - F6" }
           }
         },
         "ProcedureModifierCodeCount": { "type": ["integer", "null"], "description": "Procedure Modifier Code Count (SE)" },
@@ -233,6 +259,36 @@
         "CompoundType": { "type": ["string", "null"], "description": "Compound Type (G1)" },
         "MedicaidSubrogationControlNumber": { "type": ["string", "null"], "description": "Medicaid Subrogation Internal Control Number (N4)" },
         "PharmacyServiceType": { "type": ["string", "null"], "description": "Pharmacy Service Type (U7)" },
+        "ReconciliationId": { "type": ["string", "null"], "description": "Reconciliation ID (34) - F6" },
+        "SubmissionTypeCodeCount": { "type": ["integer", "null"], "description": "Submission Type Code Count (KZ) - F6" },
+        "SubmissionTypeCodes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Code": { "type": ["string", "null"], "description": "Submission Type Code (K8) - F6" }
+            }
+          }
+        },
+        "MultipleOrderGroupId": { "type": ["string", "null"], "description": "Multiple Order Group ID (M3) - F6" },
+        "MultipleOrderGroupReasonCode": { "type": ["string", "null"], "description": "Multiple Order Group Reason Code (M4) - F6" },
+        "TotalPrescribedQuantityRemaining": { "type": ["number", "null"], "description": "Total Prescribed Quantity Remaining (KW) - F6" },
+        "PreparationEnvironmentType": { "type": ["string", "null"], "description": "Preparation Environment Type (KU) - F6" },
+        "PreparationEnvironmentEventCode": { "type": ["string", "null"], "description": "Preparation Environment Event Code (KT) - F6" },
+        "TimeOfService": { "type": ["string", "null"], "description": "Time of Service (Y6) - F6" },
+        "SalesTransactionId": { "type": ["string", "null"], "description": "Sales Transaction ID (ZF) - F6" },
+        "ReportedAdjudicatedProgramType": { "type": ["string", "null"], "description": "Reported Adjudicated Program Type (ZS) - F6" },
+        "OriginalManufacturerProduct": {
+          "type": "object",
+          "properties": {
+            "Qualifier": { "type": ["string", "null"], "description": "Original Manufacturer Product ID Qualifier (4P) - F6" },
+            "Id": { "type": ["string", "null"], "description": "Original Manufacturer Product ID (4N) - F6" }
+          }
+        },
+        "LTPACDispenseFrequency": { "type": ["integer", "null"], "description": "LTPAC Dispense Frequency (KK) - F6" },
+        "LTPACBillingMethodology": { "type": ["string", "null"], "description": "LTPAC Billing Methodology (KH) - F6" },
+        "NumberOfLTPACDispensingEvents": { "type": ["integer", "null"], "description": "Number of LTPAC Dispensing Events (KM) - F6" },
+        "DoNotDispenseBeforeDate": { "type": ["string", "null"], "format": "date", "description": "Do Not Dispense Before Date (K9) - F6" },
         "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
       }
     },
@@ -266,6 +322,18 @@
         "GrossAmountDue": { "type": ["number", "null"], "description": "Gross Amount Due (DU)" },
         "BasisOfCostDetermination": { "type": ["string", "null"], "description": "Basis of Cost Determination (DN)" },
         "MedicaidPaidAmount": { "type": ["number", "null"], "description": "Medicaid Paid Amount (N3)" },
+        "RegulatoryFeeCount": { "type": ["integer", "null"], "description": "Regulatory Fee Count (RK) - F6" },
+        "RegulatoryFees": {
+          "type": ["array", "null"],
+          "description": "Regulatory Fees - F6",
+          "items": {
+            "type": "object",
+            "properties": {
+              "TypeCode": { "type": ["string", "null"], "description": "Regulatory Fee Type Code (RL) - F6" }
+            }
+          }
+        },
+        "SubrogationAmountRequested": { "type": ["number", "null"], "description": "Subrogation Amount Requested (KX) - F6" },
         "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
       }
     },
@@ -277,6 +345,8 @@
         "SegmentId": { "$ref": "#/$defs/SegmentId" },
         "IdQualifier": { "type": ["string", "null"], "description": "Pharmacy Provider ID Qualifier (EY)" },
         "Id": { "type": ["string", "null"], "description": "Pharmacy Provider ID (E9)" },
+        "FirstName": { "type": ["string", "null"], "description": "Provider First Name (4A) - F6" },
+        "LastName": { "type": ["string", "null"], "description": "Provider Last Name (4M) - F6" },
         "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
       }
     },
@@ -295,9 +365,12 @@
           "type": "object",
           "properties": {
             "Street": { "type": ["string", "null"], "description": "Prescriber Street Address (2K)" },
+            "StreetLine1": { "type": ["string", "null"], "description": "Prescriber Street Address Line 1 (7U) - F6" },
+            "StreetLine2": { "type": ["string", "null"], "description": "Prescriber Street Address Line 2 (7V) - F6" },
             "City": { "type": ["string", "null"], "description": "Prescriber City Address (2M)" },
             "State": { "type": ["string", "null"], "description": "Prescriber State/Province Address (2N)" },
-            "Zip": { "type": ["string", "null"], "description": "Prescriber Zip/Postal Zone (2P)" }
+            "Zip": { "type": ["string", "null"], "description": "Prescriber Zip/Postal Zone (2P)" },
+            "CountryCode": { "type": ["string", "null"], "description": "Prescriber Country Code (3C) - F6" }
           }
         },
         "PrimaryCareProvider": {
@@ -308,6 +381,21 @@
             "LastName": { "type": ["string", "null"], "description": "Primary Care Provider Last Name (4E)" }
           }
         },
+        "IdAssociatedState": { "type": ["string", "null"], "description": "Prescriber ID Associated State/Province Address (ZK) - F6" },
+        "IdAssociatedCountry": { "type": ["string", "null"], "description": "Prescriber ID Associated Country Code (3B) - F6" },
+        "PhoneExtension": { "type": ["string", "null"], "description": "Prescriber Telephone Number Extension (7T) - F6" },
+        "MiddleName": { "type": ["string", "null"], "description": "Prescriber Middle Name (0F) - F6" },
+        "AlternateId": {
+          "type": "object",
+          "properties": {
+            "Qualifier": { "type": ["string", "null"], "description": "Prescriber Alternate ID Qualifier (ZM) - F6" },
+            "Id": { "type": ["string", "null"], "description": "Prescriber Alternate ID (ZP) - F6" },
+            "AssociatedState": { "type": ["string", "null"], "description": "Prescriber Alternate ID Associated State/Province Address (ZQ) - F6" },
+            "AssociatedCountry": { "type": ["string", "null"], "description": "Prescriber Alternate ID Associated Country Code (3A) - F6" }
+          }
+        },
+        "DeaNumber": { "type": ["string", "null"], "description": "Prescriber DEA Number (KV) - F6" },
+        "PlaceOfService": { "type": ["string", "null"], "description": "Prescriber Place of Service (RG) - F6" },
         "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
       }
     },
@@ -370,6 +458,30 @@
                     "Amount": { "type": ["number", "null"], "description": "Benefit Stage Amount (MW)" }
                   }
                 }
+              },
+              "AdjudicatedProgramType": { "type": ["string", "null"], "description": "Other Payer Adjudicated Program Type (9T) - F6" },
+              "ReconciliationId": { "type": ["string", "null"], "description": "Other Payer Reconciliation ID (9V) - F6" },
+              "PercentageTaxExemptIndicator": { "type": ["string", "null"], "description": "Other Payer Percentage Tax Exempt Indicator (P7) - F6" },
+              "RegulatoryFeeTypeCount": { "type": ["integer", "null"], "description": "Other Payer Regulatory Fee Type Count (P9) - F6" },
+              "RegulatoryFees": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "TypeCode": { "type": ["string", "null"], "description": "Other Payer Regulatory Fee Type Code (RN) - F6" },
+                    "ExemptIndicator": { "type": ["string", "null"], "description": "Other Payer Regulatory Fee Exempt Indicator (P8) - F6" }
+                  }
+                }
+              },
+              "BenefitStageIndicatorCount": { "type": ["integer", "null"], "description": "Benefit Stage Indicator Count (9W) - F6" },
+              "BenefitStageIndicators": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "Indicator": { "type": ["string", "null"], "description": "Benefit Stage Indicator (9X) - F6" }
+                  }
+                }
               }
             }
           }
@@ -392,13 +504,19 @@
               "type": "object",
               "properties": {
                 "Street": { "type": ["string", "null"], "description": "Employer Street Address (CG)" },
+                "StreetLine1": { "type": ["string", "null"], "description": "Employer Street Address Line 1 (8D) - F6" },
+                "StreetLine2": { "type": ["string", "null"], "description": "Employer Street Address Line 2 (7G) - F6" },
                 "City": { "type": ["string", "null"], "description": "Employer City Address (CH)" },
                 "State": { "type": ["string", "null"], "description": "Employer State/Province Address (CI)" },
-                "Zip": { "type": ["string", "null"], "description": "Employer Zip/Postal Zone (CJ)" }
+                "Zip": { "type": ["string", "null"], "description": "Employer Zip/Postal Zone (CJ)" },
+                "CountryCode": { "type": ["string", "null"], "description": "Employer Country Code (1V) - F6" }
               }
             },
             "Phone": { "type": ["string", "null"], "description": "Employer Phone Number (CK)" },
-            "ContactName": { "type": ["string", "null"], "description": "Employer Contact Name (CL)" }
+            "PhoneExtension": { "type": ["string", "null"], "description": "Employer Telephone Number Extension (7K) - F6" },
+            "ContactName": { "type": ["string", "null"], "description": "Employer Contact Name (CL)" },
+            "ContactFirstName": { "type": ["string", "null"], "description": "Employer Contact First Name (7H) - F6" },
+            "ContactLastName": { "type": ["string", "null"], "description": "Employer Contact Last Name (7J) - F6" }
           }
         },
         "CarrierId": { "type": ["string", "null"], "description": "Carrier ID (CR)" },
@@ -414,9 +532,12 @@
               "type": "object",
               "properties": {
                 "Street": { "type": ["string", "null"], "description": "Pay To Street Address (TV)" },
+                "StreetLine1": { "type": ["string", "null"], "description": "Pay To Street Address Line 1 (7R) - F6" },
+                "StreetLine2": { "type": ["string", "null"], "description": "Pay To Street Address Line 2 (7S) - F6" },
                 "City": { "type": ["string", "null"], "description": "Pay To City Address (TW)" },
                 "State": { "type": ["string", "null"], "description": "Pay To State/Province Address (TX)" },
-                "Zip": { "type": ["string", "null"], "description": "Pay To Zip/Postal Zone (TY)" }
+                "Zip": { "type": ["string", "null"], "description": "Pay To Zip/Postal Zone (TY)" },
+                "CountryCode": { "type": ["string", "null"], "description": "Pay To Country Code (1Z) - F6" }
               }
             }
           }
@@ -480,6 +601,7 @@
         "SegmentId": { "$ref": "#/$defs/SegmentId" },
         "DosageFormDescriptionCode": { "type": ["string", "null"], "description": "Compound Dosage Form Description Code (EF)" },
         "DispensingUnitFormIndicator": { "type": ["string", "null"], "description": "Compound Dispensing Unit Form Indicator (EG)" },
+        "LevelOfComplexity": { "type": ["string", "null"], "description": "Compound Level of Complexity (AG) - F6" },
         "IngredientCount": { "type": ["integer", "null"], "description": "Compound Ingredient Component Count (EC)" },
         "Ingredients": {
           "type": "array",
@@ -594,15 +716,19 @@
       "description": "Facility Segment (AM15) - Request",
       "properties": {
         "SegmentId": { "$ref": "#/$defs/SegmentId" },
+        "IdQualifier": { "type": ["string", "null"], "description": "Facility ID Qualifier (3Z) - F6" },
         "Id": { "type": ["string", "null"], "description": "Facility ID (8C)" },
         "Name": { "type": ["string", "null"], "description": "Facility Name (3Q)" },
         "Address": {
           "type": "object",
           "properties": {
             "Street": { "type": ["string", "null"], "description": "Facility Street Address (3U)" },
+            "StreetLine1": { "type": ["string", "null"], "description": "Facility Street Address Line 1 (7M) - F6" },
+            "StreetLine2": { "type": ["string", "null"], "description": "Facility Street Address Line 2 (7N) - F6" },
             "City": { "type": ["string", "null"], "description": "Facility City Address (5J)" },
             "State": { "type": ["string", "null"], "description": "Facility State/Province Address (3V)" },
-            "Zip": { "type": ["string", "null"], "description": "Facility Zip/Postal Zone (6D)" }
+            "Zip": { "type": ["string", "null"], "description": "Facility Zip/Postal Zone (6D)" },
+            "CountryCode": { "type": ["string", "null"], "description": "Facility Country Code (1X) - F6" }
           }
         },
         "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
@@ -637,9 +763,12 @@
               "type": "object",
               "properties": {
                 "Street": { "type": ["string", "null"], "description": "Prior Authorization Authorized Representative Street Address (PG)" },
+                "StreetLine1": { "type": ["string", "null"], "description": "Prior Authorization Authorized Representative Street Address Line 1 (7D) - F6" },
+                "StreetLine2": { "type": ["string", "null"], "description": "Prior Authorization Authorized Representative Street Address Line 2 (8B) - F6" },
                 "City": { "type": ["string", "null"], "description": "Prior Authorization Authorized Representative City Address (PH)" },
                 "State": { "type": ["string", "null"], "description": "Prior Authorization Authorized Representative State/Province Address (PJ)" },
-                "Zip": { "type": ["string", "null"], "description": "Prior Authorization Authorized Representative Zip/Postal Zone (PK)" }
+                "Zip": { "type": ["string", "null"], "description": "Prior Authorization Authorized Representative Zip/Postal Zone (PK)" },
+                "CountryCode": { "type": ["string", "null"], "description": "Prior Authorization Authorized Representative Country Code (1U) - F6" }
               }
             }
           }
@@ -647,6 +776,62 @@
         "NumberAssigned": { "type": ["string", "null"], "description": "Prior Authorization Number Assigned (PY)" },
         "Number": { "type": ["string", "null"], "description": "Authorization Number (F3)" },
         "SupportingDocumentation": { "type": ["string", "null"], "description": "Prior Authorization Supporting Documentation (PP)" },
+        "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
+      }
+    },
+
+    "request.Intermediary": {
+      "type": "object",
+      "description": "Intermediary Segment (AM19) - Request - F6",
+      "properties": {
+        "SegmentId": { "$ref": "#/$defs/SegmentId" },
+        "IdCount": { "type": ["integer", "null"], "description": "Intermediary ID Count (8G)" },
+        "Ids": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "TypeCode": { "type": ["string", "null"], "description": "Intermediary Type Code (8H)" },
+              "TypeEntity": { "type": ["string", "null"], "description": "Intermediary Type Entity (8J)" },
+              "Qualifier": { "type": ["string", "null"], "description": "Intermediary ID Qualifier (8K)" },
+              "Id": { "type": ["string", "null"], "description": "Intermediary ID (8M)" },
+              "StateProvinceAddress": { "type": ["string", "null"], "description": "Intermediary State/Province Address (8N)" },
+              "CountryCode": { "type": ["string", "null"], "description": "Intermediary Country Code (8U)" }
+            }
+          }
+        },
+        "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
+      }
+    },
+
+    "request.LastKnown4Rx": {
+      "type": "object",
+      "description": "Last Known 4Rx Segment (AM37) - Request - F6",
+      "properties": {
+        "SegmentId": { "$ref": "#/$defs/SegmentId" },
+        "IinNumber": { "type": ["string", "null"], "description": "Last Known IIN Number (3E)" },
+        "ProcessorControlNumber": { "type": ["string", "null"], "description": "Last Known Processor Control Number (3F)" },
+        "GroupId": { "type": ["string", "null"], "description": "Last Known Group ID (3G)" },
+        "CardholderId": { "type": ["string", "null"], "description": "Last Known Cardholder ID (3H)" },
+        "YearOfLastPaidClaim": { "type": ["string", "null"], "description": "Year of Last Paid Claim (3J)" },
+        "MonthOfLastPaidClaim": { "type": ["string", "null"], "description": "Month of Last Paid Claim (3K)" },
+        "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
+      }
+    },
+
+    "request.NTransactionPayerIdentification": {
+      "type": "object",
+      "description": "N Transaction Payer Identification Segment (AM38) - Request - F6",
+      "properties": {
+        "SegmentId": { "$ref": "#/$defs/SegmentId" },
+        "PayerIin": { "type": ["string", "null"], "description": "Payer IIN (9Y)" },
+        "PayerProcessorControlNumber": { "type": ["string", "null"], "description": "Payer Processor Control Number (9Z)" },
+        "PayerCardholderId": { "type": ["string", "null"], "description": "Payer Cardholder ID (AA)" },
+        "PayerGroupId": { "type": ["string", "null"], "description": "Payer Group ID (AB)" },
+        "PayerAdjudicatedProgramType": { "type": ["string", "null"], "description": "Payer Adjudicated Program Type (9U)" },
+        "TransactionSourceType": { "type": ["string", "null"], "description": "Transaction Source Type (AC)" },
+        "TransactionReconciliationId": { "type": ["string", "null"], "description": "Transaction Reconciliation ID (AD)" },
+        "TransactionReferenceNumber": { "type": ["string", "null"], "description": "Transaction Reference Number (K5)" },
         "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
       }
     },
@@ -744,11 +929,23 @@
         "GroupId": { "type": ["string", "null"], "description": "Group ID (C1)" },
         "PlanId": { "type": ["string", "null"], "description": "Plan ID (FO)" },
         "NetworkReimbursementId": { "type": ["string", "null"], "description": "Network Reimbursement ID (2F)" },
+        "PayerIdCount": { "type": ["integer", "null"], "description": "Payer ID Count (KR) - F6" },
         "Payer": {
           "type": "object",
           "properties": {
             "Qualifier": { "type": ["string", "null"], "description": "Payer ID Qualifier (J7)" },
             "Id": { "type": ["string", "null"], "description": "Payer ID (J8)" }
+          }
+        },
+        "Payers": {
+          "type": ["array", "null"],
+          "description": "Payer IDs - every J7/J8 occurrence when repeating; the singular Payer object retains a single occurrence for backward compatibility - F6",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Qualifier": { "type": ["string", "null"], "description": "Payer ID Qualifier (J7)" },
+              "Id": { "type": ["string", "null"], "description": "Payer ID (J8)" }
+            }
           }
         },
         "Medicaid": {
@@ -780,7 +977,8 @@
           }
         },
         "ContractNumber": { "type": ["string", "null"], "description": "Contract Number (U1)" },
-        "FormularyId": { "type": ["string", "null"], "description": "Formulary ID (FF)" }
+        "FormularyId": { "type": ["string", "null"], "description": "Formulary ID (FF)" },
+        "PlanName": { "type": ["string", "null"], "description": "Plan Name (96) - F6" }
       }
     },
 
@@ -789,6 +987,17 @@
       "description": "Patient Segment (AM29) - Response",
       "properties": {
         "SegmentId": { "$ref": "#/$defs/SegmentId" },
+        "IdCount": { "type": ["integer", "null"], "description": "Patient ID Count (RR) - F6" },
+        "Ids": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Qualifier": { "type": ["string", "null"], "description": "Patient ID Qualifier (CX) - F6" },
+              "Id": { "type": ["string", "null"], "description": "Patient ID (CY) - F6" }
+            }
+          }
+        },
         "FirstName": { "type": ["string", "null"], "description": "Patient First Name (CA)" },
         "LastName": { "type": ["string", "null"], "description": "Patient Last Name (CB)" },
         "BirthDate": { "type": ["string", "null"], "format": "date", "description": "Patient Date of Birth (C4)" },
@@ -846,6 +1055,32 @@
         "TransactionReferenceNumber": { "type": ["string", "null"], "description": "Transaction Reference Number (K5)" },
         "InternalControlNumber": { "type": ["string", "null"], "description": "Internal Control Number (A7)" },
         "Url": { "type": ["string", "null"], "description": "URL (MA)" },
+        "ReconciliationId": { "type": ["string", "null"], "description": "Reconciliation ID (34) - F6" },
+        "HelpDeskSupportTypeCount": { "type": ["integer", "null"], "description": "Help Desk Support Type Count (BH) - F6" },
+        "HelpDeskSupportTypes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Type": { "type": ["string", "null"], "description": "Help Desk Support Type (BG) - F6" }
+            }
+          }
+        },
+        "HelpDeskBusinessUnitTypeCount": { "type": ["integer", "null"], "description": "Help Desk Business Unit Type Count (BB) - F6" },
+        "HelpDeskBusinessUnits": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Type": { "type": ["string", "null"], "description": "Help Desk Business Unit Type (BA) - F6" },
+              "ContactInformationQualifier": { "type": ["string", "null"], "description": "Help Desk Contact Information Qualifier (BF) - F6" },
+              "ContactInformation": { "type": ["string", "null"], "description": "Help Desk Contact Information (BC) - F6" }
+            }
+          }
+        },
+        "HelpDeskContactInformationExtension": { "type": ["string", "null"], "description": "Help Desk Contact Information Extension (BD) - F6" },
+        "AdjudicatedProgramType": { "type": ["string", "null"], "description": "Adjudicated Program Type (ZR) - F6" },
+        "NextAvailableFillDate": { "type": ["string", "null"], "format": "date", "description": "Next Available Fill Date (BT) - F6" },
         "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
       }
     },
@@ -872,11 +1107,64 @@
               "Id": { "type": ["string", "null"], "description": "Preferred Product ID (AR)" },
               "Incentive": { "type": ["number", "null"], "description": "Preferred Product Incentive (AS)" },
               "CostShareIncentive": { "type": ["number", "null"], "description": "Preferred Product Cost Share Incentive (AT)" },
-              "Description": { "type": ["string", "null"], "description": "Preferred Product Description (AU)" }
+              "Description": { "type": ["string", "null"], "description": "Preferred Product Description (AU)" },
+              "EffectiveDate": { "type": ["string", "null"], "format": "date", "description": "Preferred Product Effective Date (ZO) - F6" },
+              "PlanBenefitTier": { "type": ["string", "null"], "description": "Preferred Product Plan Benefit Tier (PV) - F6" },
+              "ReasonCode": { "type": ["string", "null"], "description": "Preferred Product Reason Code (PZ) - F6" },
+              "RequiredTherapyIndicatorCount": { "type": ["integer", "null"], "description": "Required Therapy Indicator Count (P0) - F6" },
+              "RequiredTherapyIndicators": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "Indicator": { "type": ["string", "null"], "description": "Required Therapy Indicator (P1) - F6" }
+                  }
+                }
+              },
+              "RequiredTherapyTimePeriodQualifier": { "type": ["string", "null"], "description": "Required Therapy Time Period Qualifier (P2) - F6" },
+              "RequiredTherapyTimePeriodDuration": { "type": ["string", "null"], "description": "Required Therapy Time Period Duration (P3) - F6" },
+              "RequiredTherapyTimePeriodStartDate": { "type": ["string", "null"], "format": "date", "description": "Required Therapy Time Period Start Date (P4) - F6" },
+              "RequiredTherapyTimePeriodEndDate": { "type": ["string", "null"], "format": "date", "description": "Required Therapy Time Period End Date (P5) - F6" }
             }
           }
         },
         "MedicaidSubrogationInternalControlNumber": { "type": ["string", "null"], "description": "Medicaid Subrogation Internal Control Number (N4)" },
+        "PlanBenefitOverrideIndicator": { "type": ["string", "null"], "description": "Plan Benefit Override Indicator (RC) - F6" },
+        "PlanBenefitOverrideValueCount": { "type": ["integer", "null"], "description": "Plan Benefit Override Value Count (RD) - F6" },
+        "PlanBenefitOverrideValues": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Value": { "type": ["string", "null"], "description": "Plan Benefit Override Value (RF) - F6" }
+            }
+          }
+        },
+        "MaximumAgeQualifier": { "type": ["string", "null"], "description": "Maximum Age Qualifier (F8) - F6" },
+        "MaximumAge": { "type": ["integer", "null"], "description": "Maximum Age (GA) - F6" },
+        "MinimumAgeQualifier": { "type": ["string", "null"], "description": "Minimum Age Qualifier (GQ) - F6" },
+        "MinimumAge": { "type": ["integer", "null"], "description": "Minimum Age (GR) - F6" },
+        "MinimumAmountQualifier": { "type": ["string", "null"], "description": "Minimum Amount Qualifier (M2) - F6" },
+        "MinimumAmount": { "type": ["number", "null"], "description": "Minimum Amount (M1) - F6" },
+        "MaximumAmountQualifier": { "type": ["string", "null"], "description": "Maximum Amount Qualifier (GC) - F6" },
+        "MaximumAmount": { "type": ["number", "null"], "description": "Maximum Amount (GB) - F6" },
+        "MaximumAmountTimePeriod": { "type": ["string", "null"], "description": "Maximum Amount Time Period (GF) - F6" },
+        "MaximumAmountTimePeriodEndDate": { "type": ["string", "null"], "format": "date", "description": "Maximum Amount Time Period End Date (GH) - F6" },
+        "MaximumAmountTimePeriodStartDate": { "type": ["string", "null"], "format": "date", "description": "Maximum Amount Time Period Start Date (GG) - F6" },
+        "MaximumAmountTimePeriodUnits": { "type": ["integer", "null"], "description": "Maximum Amount Time Period Units (GJ) - F6" },
+        "RemainingAmountQualifier": { "type": ["string", "null"], "description": "Remaining Amount Qualifier (M7) - F6" },
+        "RemainingAmount": { "type": ["number", "null"], "description": "Remaining Amount (M6) - F6" },
+        "BenefitTypeOpportunityCount": { "type": ["integer", "null"], "description": "Benefit Type Opportunity Count (AF) - F6" },
+        "BenefitTypeOpportunities": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Opportunity": { "type": ["string", "null"], "description": "Benefit Type Opportunity (AE) - F6" }
+            }
+          }
+        },
+        "SubrogationRequestorsReconciliationId": { "type": ["string", "null"], "description": "Subrogation Requestor's Reconciliation ID (KY) - F6" },
         "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
       }
     },
@@ -952,6 +1240,40 @@
         "AmountAttributedToCoverageGap": { "type": ["number", "null"], "description": "Amount Attributed to Coverage Gap (UP)" },
         "IngredientCostContractedReimbursableAmount": { "type": ["number", "null"], "description": "Ingredient Cost Contracted/Reimbursable Amount (U8)" },
         "DispensingFeeContractedReimbursableAmount": { "type": ["number", "null"], "description": "Dispensing Fee Contracted/Reimbursable Amount (U9)" },
+        "PatientPayComponentCount": { "type": ["integer", "null"], "description": "Patient Pay Component Count (KP) - F6" },
+        "PatientPayComponents": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Qualifier": { "type": ["string", "null"], "description": "Patient Pay Component Qualifier (KQ) - F6" },
+              "Amount": { "type": ["number", "null"], "description": "Patient Pay Component Amount (KN) - F6" }
+            }
+          }
+        },
+        "RegulatoryFeeCount": { "type": ["integer", "null"], "description": "Regulatory Fee Count (RK) - F6" },
+        "RegulatoryFees": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "TypeCode": { "type": ["string", "null"], "description": "Regulatory Fee Type Code (RL) - F6" },
+              "ExemptIndicator": { "type": ["string", "null"], "description": "Regulatory Fee Exempt Indicator (RM) - F6" }
+            }
+          }
+        },
+        "BenefitStageIndicatorCount": { "type": ["integer", "null"], "description": "Benefit Stage Indicator Count (9W) - F6" },
+        "BenefitStageIndicators": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Indicator": { "type": ["string", "null"], "description": "Benefit Stage Indicator (9X) - F6" }
+            }
+          }
+        },
+        "PatientRegulatoryFeeAmount": { "type": ["number", "null"], "description": "Patient Regulatory Fee Amount (RS) - F6" },
+        "ProfessionalServiceFeeContractedReimbursableAmount": { "type": ["number", "null"], "description": "Professional Service Fee Contracted/Reimbursable Amount (6G) - F6" },
         "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
       }
     },
@@ -975,7 +1297,25 @@
               "DatabaseIndicator": { "type": ["string", "null"], "description": "DUR/PPS Database Indicator (FW)" },
               "OtherPrescriberIndicator": { "type": ["string", "null"], "description": "Other Prescriber Indicator (FX)" },
               "FreeText": { "type": ["string", "null"], "description": "DUR Free Text Message (FY)" },
-              "AdditionalText": { "type": ["string", "null"], "description": "DUR Additional Text (NS)" }
+              "AdditionalText": { "type": ["string", "null"], "description": "DUR Additional Text (NS)" },
+              "CoAgentIdQualifier": { "type": ["string", "null"], "description": "DUR Co-Agent ID Qualifier (J9) - F6" },
+              "CoAgentId": { "type": ["string", "null"], "description": "DUR Co-Agent ID (H6) - F6" },
+              "CoAgentDescription": { "type": ["string", "null"], "description": "DUR Co-Agent Description (ZC) - F6" },
+              "OtherPharmacyIdQualifier": { "type": ["string", "null"], "description": "Other Pharmacy ID Qualifier (Z9) - F6" },
+              "OtherPharmacyId": { "type": ["string", "null"], "description": "Other Pharmacy ID (Z8) - F6" },
+              "OtherPharmacyName": { "type": ["string", "null"], "description": "Other Pharmacy Name (Z7) - F6" },
+              "OtherPharmacyTelephone": { "type": ["string", "null"], "description": "Other Pharmacy Telephone Number (Z6) - F6" },
+              "UnitOfMeasureForPreviousDispensedQuantity": { "type": ["string", "null"], "description": "Unit of Measure for Previous Dispensed Quantity (ZA) - F6" },
+              "OtherPrescriberIdQualifier": { "type": ["string", "null"], "description": "Other Prescriber ID Qualifier (Z4) - F6" },
+              "OtherPrescriberId": { "type": ["string", "null"], "description": "Other Prescriber ID (Z3) - F6" },
+              "OtherPrescriberLastName": { "type": ["string", "null"], "description": "Other Prescriber Last Name (Z5) - F6" },
+              "OtherPrescriberTelephoneNumber": { "type": ["string", "null"], "description": "Other Prescriber Telephone Number (Z2) - F6" },
+              "CompoundProductIdQualifier": { "type": ["string", "null"], "description": "Compound Product ID Qualifier (Z0) - F6" },
+              "CompoundProductId": { "type": ["string", "null"], "description": "Compound Product ID (Z1) - F6" },
+              "MaximumDailyDoseQuantity": { "type": ["number", "null"], "description": "Maximum Daily Dose Quantity (YO) - F6" },
+              "MaximumDailyDoseUnitOfMeasure": { "type": ["string", "null"], "description": "Maximum Daily Dose Unit of Measure (YL) - F6" },
+              "MinimumDailyDoseQuantity": { "type": ["number", "null"], "description": "Minimum Daily Dose Quantity (YJ) - F6" },
+              "MinimumDailyDoseUnitOfMeasure": { "type": ["string", "null"], "description": "Minimum Daily Dose Unit of Measure (YI) - F6" }
             }
           }
         },
@@ -1021,10 +1361,134 @@
               "HelpDeskPhone": { "type": ["string", "null"], "description": "Other Payer Help Desk Phone Number (UB)" },
               "PatientRelationshipCode": { "type": ["string", "null"], "description": "Other Payer Patient Relationship Code (UW)" },
               "BenefitEffectiveDate": { "type": ["string", "null"], "format": "date", "description": "Other Payer Benefit Effective Date (UX)" },
-              "BenefitTerminationDate": { "type": ["string", "null"], "format": "date", "description": "Other Payer Benefit Termination Date (UY)" }
+              "BenefitTerminationDate": { "type": ["string", "null"], "format": "date", "description": "Other Payer Benefit Termination Date (UY)" },
+              "RelationshipType": { "type": ["string", "null"], "description": "Other Payer Relationship Type (PQ) - F6" },
+              "BenefitClassification": { "type": ["string", "null"], "description": "Other Payer Benefit Classification (P6) - F6" },
+              "AdjudicatedProgramType": { "type": ["string", "null"], "description": "Other Payer Adjudicated Program Type (9T) - F6" },
+              "Name": { "type": ["string", "null"], "description": "Other Payer Name (M5) - F6" },
+              "HelpDeskPhoneExtension": { "type": ["string", "null"], "description": "Other Payer Help Desk Telephone Number Extension (7Q) - F6" }
             }
           }
         },
+        "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
+      }
+    },
+
+    "response.Intermediary": {
+      "type": "object",
+      "description": "Intermediary Segment (AM36) - Response - F6",
+      "properties": {
+        "SegmentId": { "$ref": "#/$defs/SegmentId" },
+        "AuthorizationCount": { "type": ["integer", "null"], "description": "Intermediary Authorization Count (8R)" },
+        "Authorizations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "TypeId": { "type": ["string", "null"], "description": "Intermediary Authorization Type ID (8S)" },
+              "Id": { "type": ["string", "null"], "description": "Intermediary Authorization ID (8T)" }
+            }
+          }
+        },
+        "Messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Message": { "type": ["string", "null"], "description": "Intermediary Message (8Q)" }
+            }
+          }
+        },
+        "HelpDeskSupportTypeCount": { "type": ["integer", "null"], "description": "Intermediary Help Desk Support Type Count (KC)" },
+        "HelpDeskSupportTypes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Type": { "type": ["string", "null"], "description": "Intermediary Help Desk Support Type (KB)" }
+            }
+          }
+        },
+        "HelpDeskBusinessUnitTypeCount": { "type": ["integer", "null"], "description": "Intermediary Help Desk Business Unit Type Count (G9)" },
+        "HelpDeskBusinessUnits": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Type": { "type": ["string", "null"], "description": "Intermediary Help Desk Business Unit Type (G8)" },
+              "ContactInformationQualifier": { "type": ["string", "null"], "description": "Intermediary Help Desk Contact Information Qualifier (KA)" },
+              "ContactInformation": { "type": ["string", "null"], "description": "Intermediary Help Desk Contact Information (JP)" },
+              "ContactInformationExtension": { "type": ["string", "null"], "description": "Intermediary Help Desk Contact Information Extension (JR)" }
+            }
+          }
+        },
+        "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
+      }
+    },
+
+    "response.OtherRelatedBenefitDetail": {
+      "type": "object",
+      "description": "Other Related Benefit Detail Segment (AM39) - Response - F6",
+      "properties": {
+        "SegmentId": { "$ref": "#/$defs/SegmentId" },
+        "PlanType": { "type": ["string", "null"], "description": "Plan Type (KS)" },
+        "LisLevel": { "type": ["string", "null"], "description": "LIS Level (KF)" },
+        "LisEffectiveDate": { "type": ["string", "null"], "format": "date", "description": "LIS Effective Date (KD)" },
+        "LisTerminationDate": { "type": ["string", "null"], "format": "date", "description": "LIS Termination Date (KG)" },
+        "DisabilityEffectiveDate": { "type": ["string", "null"], "format": "date", "description": "Disability Effective Date (AH)" },
+        "EsrdIndicator": { "type": ["string", "null"], "description": "ESRD Indicator (A5)" },
+        "EsrdEffectiveDate": { "type": ["string", "null"], "format": "date", "description": "ESRD Effective Date (AJ)" },
+        "EsrdTerminationDate": { "type": ["string", "null"], "format": "date", "description": "ESRD Termination Date (A6)" },
+        "HospiceEffectiveDate": { "type": ["string", "null"], "format": "date", "description": "Hospice Effective Date (G4)" },
+        "HospiceTerminationDate": { "type": ["string", "null"], "format": "date", "description": "Hospice Termination Date (G7)" },
+        "HospiceProviderNumber": { "type": ["string", "null"], "description": "Hospice Provider Number (G6)" },
+        "HospiceFacilityName": { "type": ["string", "null"], "description": "Hospice Facility Name (G5)" },
+        "HospiceTelephoneNumber": { "type": ["string", "null"], "description": "Hospice Telephone Number (A8)" },
+        "InstitutionalIndicator": { "type": ["string", "null"], "description": "Institutional Indicator (BJ)" },
+        "InstitutionalEffectiveDate": { "type": ["string", "null"], "format": "date", "description": "Institutional Effective Date (BK)" },
+        "InstitutionalTerminationDate": { "type": ["string", "null"], "format": "date", "description": "Institutional Termination Date (GD)" },
+        "OtherBenefitCount": { "type": ["integer", "null"], "description": "Other Benefit Count (M8)" },
+        "OtherBenefits": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "TypeCode": { "type": ["string", "null"], "description": "Other Benefit Type Code (PN)" },
+              "EffectiveDate": { "type": ["string", "null"], "format": "date", "description": "Other Benefit Effective Date (MZ)" },
+              "TerminationDate": { "type": ["string", "null"], "format": "date", "description": "Other Benefit Termination Date (NN)" },
+              "StateProvinceAddress": { "type": ["string", "null"], "description": "Other Benefit State/Province Address (TA)" },
+              "TypeId": { "type": ["string", "null"], "description": "Other Benefit Type ID (N9)" },
+              "FacilityName": { "type": ["string", "null"], "description": "Other Benefit Facility Name (N1)" },
+              "FacilityTelephoneNumber": { "type": ["string", "null"], "description": "Other Benefit Facility Telephone Number (N7)" }
+            }
+          }
+        },
+        "OtherBenefitDetailInformationCount": { "type": ["integer", "null"], "description": "Other Benefit Detail Information Count (N8)" },
+        "OtherBenefitDetailInformation": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Indicator": { "type": ["string", "null"], "description": "Other Benefit Detail Information Indicator (MS)" },
+              "EffectiveDate": { "type": ["string", "null"], "format": "date", "description": "Other Benefit Detail Information Effective Date (MM)" },
+              "TerminationDate": { "type": ["string", "null"], "format": "date", "description": "Other Benefit Detail Information Termination Date (MX)" },
+              "ProviderNumber": { "type": ["string", "null"], "description": "Other Benefit Detail Information Provider Number (MR)" },
+              "FacilityName": { "type": ["string", "null"], "description": "Other Benefit Detail Information Facility Name (MN)" },
+              "FacilityTelephoneNumber": { "type": ["string", "null"], "description": "Other Benefit Detail Information Facility Telephone Number (MP)" }
+            }
+          }
+        },
+        "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
+      }
+    },
+
+    "response.Provider": {
+      "type": "object",
+      "description": "Provider Segment (AM40) - Response - F6",
+      "properties": {
+        "SegmentId": { "$ref": "#/$defs/SegmentId" },
+        "DataSourceOfInvalidProviderDetermination": { "type": ["string", "null"], "description": "Data Source of Invalid Provider Determination (ZV)" },
+        "StateCodeForDataSourceOfInvalidProviderDetermination": { "type": ["string", "null"], "description": "State Code for Data Source of Invalid Provider Determination (ZZ)" },
         "DynamicFields": { "type": "array", "items": { "$ref": "#/$defs/DynamicStruct" } }
       }
     }

--- a/pkg/serde/serde.go
+++ b/pkg/serde/serde.go
@@ -124,13 +124,11 @@ func getRegisteredType(key string) (reflect.Type, error) {
 }
 
 func GetRequestType(tranCode string) (reflect.Type, error) {
-	key := fmt.Sprintf("%v|request", tranCode)
-	return getRegisteredType(key)
+	return getRegisteredType(tranCode + "|request")
 }
 
 func GetResponseType(tranCode string) (reflect.Type, error) {
-	key := fmt.Sprintf("%v|response", tranCode)
-	return getRegisteredType(key)
+	return getRegisteredType(tranCode + "|response")
 }
 
 // Register types we need to dynamically create.
@@ -178,8 +176,14 @@ func RegisterTypes() {
 	})
 }
 
+var segmentAttributeCache sync.Map
+
 // Get segment attribute data.
 func GetSegmentAttribute(tag string) (SegmentAttribute, error) {
+	if cached, ok := segmentAttributeCache.Load(tag); ok {
+		return cached.(SegmentAttribute), nil
+	}
+
 	attribute := SegmentAttribute{}
 
 	tagFields := strings.Split(tag, ",")
@@ -197,6 +201,8 @@ func GetSegmentAttribute(tag string) (SegmentAttribute, error) {
 			attribute.Order, _ = strconv.Atoi(parseTag(tagField, OrderTag))
 		}
 	}
+
+	segmentAttributeCache.Store(tag, attribute)
 
 	return attribute, nil
 }
@@ -225,8 +231,14 @@ func GetHeaderAttribute(tag string) (HeaderAttribute, error) {
 	return attribute, nil
 }
 
+var fieldAttributeCache sync.Map
+
 // Get field attribute data.
 func GetFieldAttribute(tag string) (FieldAttribute, error) {
+	if cached, ok := fieldAttributeCache.Load(tag); ok {
+		return cached.(FieldAttribute), nil
+	}
+
 	attribute := FieldAttribute{}
 
 	tagFields := strings.Split(tag, ",")
@@ -254,6 +266,8 @@ func GetFieldAttribute(tag string) (FieldAttribute, error) {
 		}
 	}
 
+	fieldAttributeCache.Store(tag, attribute)
+
 	return attribute, nil
 }
 
@@ -264,22 +278,25 @@ func inferFormat(key string) string {
 
 // Parse tag data for specified key/value pair.
 func parseTag(tagField, tagKey string) string {
-	if !strings.HasPrefix(tagField, tagKey) {
+	tagValue, found := strings.CutPrefix(tagField, tagKey+"=")
+	if !found {
 		return Empty
 	}
-
-	tagFormat := fmt.Sprintf("%v=", tagKey) + "%v"
-	var tagValue string
-
-	fmt.Sscanf(tagField, tagFormat, &tagValue)
 
 	return tagValue
 }
 
-// Get map of segment definitions by segment ID.
+var segmentDefinitionByIdCache sync.Map
+
+// Get map of segment definitions by segment ID. The returned map is cached and must not be modified.
 func GetSegmentDefinitionById(tType reflect.Type) (map[string]SegmentDefinition, error) {
-	segmentMap := make(map[string]SegmentDefinition)
 	baseType := reflectionutils.GetElementType(tType)
+
+	if cached, ok := segmentDefinitionByIdCache.Load(baseType); ok {
+		return cached.(map[string]SegmentDefinition), nil
+	}
+
+	segmentMap := make(map[string]SegmentDefinition)
 
 	for i := 0; i < baseType.NumField(); i++ {
 		field := baseType.Field(i)
@@ -295,13 +312,22 @@ func GetSegmentDefinitionById(tType reflect.Type) (map[string]SegmentDefinition,
 		}
 	}
 
+	segmentDefinitionByIdCache.Store(baseType, segmentMap)
+
 	return segmentMap, nil
 }
 
-// Get map of segment definitions by segment order.
+var segmentDefinitionByOrderCache sync.Map
+
+// Get map of segment definitions by segment order. The returned map is cached and must not be modified.
 func GetSegmentDefinitionByOrder(tType reflect.Type) (map[int]SegmentDefinition, error) {
-	segmentMap := make(map[int]SegmentDefinition)
 	baseType := reflectionutils.GetElementType(tType)
+
+	if cached, ok := segmentDefinitionByOrderCache.Load(baseType); ok {
+		return cached.(map[int]SegmentDefinition), nil
+	}
+
+	segmentMap := make(map[int]SegmentDefinition)
 
 	for i := 0; i < baseType.NumField(); i++ {
 		field := baseType.Field(i)
@@ -318,6 +344,8 @@ func GetSegmentDefinitionByOrder(tType reflect.Type) (map[int]SegmentDefinition,
 			}
 		}
 	}
+
+	segmentDefinitionByOrderCache.Store(baseType, segmentMap)
 
 	return segmentMap, nil
 }
@@ -431,10 +459,7 @@ func GetDynamicSlice(tType reflect.Type, tagType string) (*reflect.StructField, 
 // Create dynamic field name. Handle repeating fields by
 // including the element index within the name.
 func DynamicFieldName(fieldCode string, order int) string {
-	return fmt.Sprintf(
-		"Field_%v_%v",
-		replaceIllegalCharacters(fieldCode),
-		order)
+	return "Field_" + replaceIllegalCharacters(fieldCode) + "_" + strconv.Itoa(order)
 }
 
 // Replace illegal characters in field names.

--- a/pkg/serde/serde_test.go
+++ b/pkg/serde/serde_test.go
@@ -1,0 +1,118 @@
+package serde
+
+import "testing"
+
+func Test_ParseTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		tagField string
+		tagKey   string
+		want     string
+	}{
+		{"simple value", "code=AM07", "code", "AM07"},
+		{"empty value", "code=", "code", ""},
+		{"key mismatch", "order=5", "code", ""},
+		{"key that is a prefix of another key does not match", "decimalPlaces=2", "decimal", ""},
+		{"value containing whitespace is preserved", "format=YYYY MMdd", "format", "YYYY MMdd"},
+		{"no equals sign", "code", "code", ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := parseTag(test.tagField, test.tagKey)
+			if got != test.want {
+				t.Errorf("parseTag(%q, %q) mismatch. Wanted: %q   Got: %q", test.tagField, test.tagKey, test.want, got)
+			}
+		})
+	}
+}
+
+func Test_GetFieldAttribute_ParsesAllKeys(t *testing.T) {
+	attr, err := GetFieldAttribute("code=D7,order=5,decimalPlaces=2,overpunch=true,format=YYYYMMdd")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if attr.Code != "D7" {
+		t.Errorf("Code mismatch. Wanted: D7   Got: %q", attr.Code)
+	}
+	if attr.Order != 5 {
+		t.Errorf("Order mismatch. Wanted: 5   Got: %v", attr.Order)
+	}
+	if attr.DecimalPlaces != 2 {
+		t.Errorf("DecimalPlaces mismatch. Wanted: 2   Got: %v", attr.DecimalPlaces)
+	}
+	if !attr.Overpunch {
+		t.Error("Overpunch mismatch. Wanted: true   Got: false")
+	}
+	if attr.Format != "20060102" {
+		t.Errorf("Format mismatch. Wanted: 20060102   Got: %q", attr.Format)
+	}
+	if attr.Dynamic {
+		t.Error("Dynamic mismatch. Wanted: false   Got: true")
+	}
+}
+
+func Test_GetFieldAttribute_Dynamic(t *testing.T) {
+	attr, err := GetFieldAttribute("code=dynamic")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !attr.Dynamic {
+		t.Error("Dynamic mismatch. Wanted: true   Got: false")
+	}
+}
+
+func Test_GetFieldAttribute_CacheReturnsSameResult(t *testing.T) {
+	const tag = "code=E7,order=9,decimalPlaces=3"
+
+	first, err := GetFieldAttribute(tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := GetFieldAttribute(tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if first != second {
+		t.Errorf("Cached attribute mismatch.\nFirst:  %+v\nSecond: %+v", first, second)
+	}
+}
+
+func Test_GetSegmentAttribute_ParsesAllKeys(t *testing.T) {
+	attr, err := GetSegmentAttribute("code=AM07,order=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if attr.Code != "AM07" {
+		t.Errorf("Code mismatch. Wanted: AM07   Got: %q", attr.Code)
+	}
+	if attr.Order != 1 {
+		t.Errorf("Order mismatch. Wanted: 1   Got: %v", attr.Order)
+	}
+	if attr.Dynamic {
+		t.Error("Dynamic mismatch. Wanted: false   Got: true")
+	}
+}
+
+func Test_GetSegmentAttribute_CacheReturnsSameResult(t *testing.T) {
+	const tag = "code=AM11,order=7"
+
+	first, err := GetSegmentAttribute(tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := GetSegmentAttribute(tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if first != second {
+		t.Errorf("Cached attribute mismatch.\nFirst:  %+v\nSecond: %+v", first, second)
+	}
+}

--- a/pkg/serde/serde_test.go
+++ b/pkg/serde/serde_test.go
@@ -99,6 +99,62 @@ func Test_GetSegmentAttribute_ParsesAllKeys(t *testing.T) {
 	}
 }
 
+func Test_GetRequestType(t *testing.T) {
+	RegisterTypes()
+
+	tranType, err := GetRequestType("B1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tranType.Name() != "Billing" {
+		t.Errorf("Request type mismatch. Wanted: Billing   Got: %v", tranType.Name())
+	}
+
+	if _, err := GetRequestType("ZZ"); err == nil {
+		t.Error("Expected error for unknown request transaction code, got nil")
+	}
+}
+
+func Test_GetResponseType(t *testing.T) {
+	RegisterTypes()
+
+	tranType, err := GetResponseType("B2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tranType.Name() != "Reversal" {
+		t.Errorf("Response type mismatch. Wanted: Reversal   Got: %v", tranType.Name())
+	}
+
+	if _, err := GetResponseType("ZZ"); err == nil {
+		t.Error("Expected error for unknown response transaction code, got nil")
+	}
+}
+
+func Test_DynamicFieldName(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldCode string
+		order     int
+		want      string
+	}{
+		{"plain code", "D7", 3, "Field_D7_3"},
+		{"ampersand replaced", "&B", 1, "Field_ampersandB_1"},
+		{"hash replaced", "#A", 2, "Field_hashA_2"},
+		{"exclamation replaced", "!F", 7, "Field_exclamationF_7"},
+		{"multiple illegal characters", "{}", 4, "Field_leftbracerightbrace_4"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := DynamicFieldName(test.fieldCode, test.order)
+			if got != test.want {
+				t.Errorf("DynamicFieldName(%q, %v) mismatch. Wanted: %q   Got: %q", test.fieldCode, test.order, test.want, got)
+			}
+		})
+	}
+}
+
 func Test_GetSegmentAttribute_CacheReturnsSameResult(t *testing.T) {
 	const tag = "code=AM11,order=7"
 

--- a/pkg/stringUtils/stringHelper.go
+++ b/pkg/stringUtils/stringHelper.go
@@ -49,19 +49,22 @@ func IndexAt(str, searchTerm string, startIndex int) int {
 // Find first index of any of the specified characters.
 // Returns -1 when not found.
 func IndexOfAny(str string, fromIndex int, searchFor []byte) int {
-	if str == "" || len(searchFor) == 0 {
+	if str == "" || len(searchFor) == 0 || fromIndex >= len(str) {
 		return -1
 	}
 
-	for i := fromIndex; i < len(str); i++ {
-		ch := str[i]
-
-		if slices.Contains(searchFor, ch) {
-			return i
-		}
+	var index int
+	if len(searchFor) == 1 {
+		index = strings.IndexByte(str[fromIndex:], searchFor[0])
+	} else {
+		index = strings.IndexAny(str[fromIndex:], string(searchFor))
 	}
 
-	return -1
+	if index < 0 {
+		return -1
+	}
+
+	return index + fromIndex
 }
 
 // Get a section of a string.

--- a/pkg/stringUtils/stringHelper_test.go
+++ b/pkg/stringUtils/stringHelper_test.go
@@ -1,0 +1,40 @@
+package stringutils
+
+import "testing"
+
+func Test_IndexOfAny(t *testing.T) {
+	const seg = byte(0x1E)
+	const grp = byte(0x1D)
+
+	tests := []struct {
+		name      string
+		str       string
+		fromIndex int
+		searchFor []byte
+		want      int
+	}{
+		{"empty string", "", 0, []byte{seg}, -1},
+		{"empty search set", "abc", 0, nil, -1},
+		{"fromIndex at end", "abc", 3, []byte{'b'}, -1},
+		{"fromIndex past end", "abc", 10, []byte{'b'}, -1},
+		{"single byte match at start", "\x1Eabc", 0, []byte{seg}, 0},
+		{"single byte match mid string", "ab\x1Ecd", 0, []byte{seg}, 2},
+		{"single byte match at last byte", "abc\x1E", 0, []byte{seg}, 3},
+		{"single byte match at fromIndex", "ab\x1Ec", 2, []byte{seg}, 2},
+		{"single byte skips match before fromIndex", "\x1Eab\x1Ecd", 1, []byte{seg}, 3},
+		{"single byte no match", "abcd", 0, []byte{seg}, -1},
+		{"multi byte earliest match wins", "ab\x1Dc\x1Ed", 0, []byte{seg, grp}, 2},
+		{"multi byte respects fromIndex", "ab\x1Dc\x1Ed", 3, []byte{seg, grp}, 4},
+		{"multi byte no match", "abcd", 0, []byte{seg, grp}, -1},
+		{"multi-byte rune content before separator", "ab€\x1Ec", 0, []byte{seg}, 5},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := IndexOfAny(test.str, test.fromIndex, test.searchFor)
+			if got != test.want {
+				t.Errorf("IndexOfAny(%q, %v, %v) mismatch. Wanted: %v   Got: %v", test.str, test.fromIndex, test.searchFor, test.want, got)
+			}
+		})
+	}
+}

--- a/pkg/stringUtils/stringHelper_test.go
+++ b/pkg/stringUtils/stringHelper_test.go
@@ -1,6 +1,9 @@
 package stringutils
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func Test_IndexOfAny(t *testing.T) {
 	const seg = byte(0x1E)
@@ -34,6 +37,207 @@ func Test_IndexOfAny(t *testing.T) {
 			got := IndexOfAny(test.str, test.fromIndex, test.searchFor)
 			if got != test.want {
 				t.Errorf("IndexOfAny(%q, %v, %v) mismatch. Wanted: %v   Got: %v", test.str, test.fromIndex, test.searchFor, test.want, got)
+			}
+		})
+	}
+}
+
+func Test_Substring(t *testing.T) {
+	tests := []struct {
+		name      string
+		str       string
+		fromIndex int
+		length    int
+		want      string
+	}{
+		{"empty string", "", 0, 3, ""},
+		{"fromIndex past end", "abc", 5, 1, ""},
+		{"fromIndex at end", "abc", 3, -1, ""},
+		{"negative length returns remainder", "abcdef", 2, -1, "cdef"},
+		{"zero length returns empty", "abcdef", 2, 0, ""},
+		{"length in range", "abcdef", 1, 3, "bcd"},
+		{"length past end returns remainder", "abcdef", 4, 10, "ef"},
+		{"whole string", "abcdef", 0, 6, "abcdef"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := Substring(test.str, test.fromIndex, test.length)
+			if got != test.want {
+				t.Errorf("Substring(%q, %v, %v) mismatch. Wanted: %q   Got: %q", test.str, test.fromIndex, test.length, test.want, got)
+			}
+		})
+	}
+}
+
+func Test_RightPadExact(t *testing.T) {
+	tests := []struct {
+		name    string
+		str     string
+		padChar byte
+		length  int
+		want    string
+	}{
+		{"pads short string", "B1", ' ', 5, "B1   "},
+		{"exact length unchanged", "B1", ' ', 2, "B1"},
+		{"truncates long string", "BILLING", ' ', 4, "BILL"},
+		{"pads empty string", "", '0', 3, "000"},
+		{"zero length returns empty", "AB", ' ', 0, ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := RightPadExact(test.str, test.padChar, test.length)
+			if got != test.want {
+				t.Errorf("RightPadExact(%q, %q, %v) mismatch. Wanted: %q   Got: %q", test.str, test.padChar, test.length, test.want, got)
+			}
+		})
+	}
+}
+
+func Test_TrimAll(t *testing.T) {
+	tests := []struct {
+		name      string
+		str       string
+		trimChars []byte
+		want      string
+	}{
+		{"trims both ends", "  AB12  ", []byte{' '}, "AB12"},
+		{"trims multiple characters", "0 0AB120 ", []byte{' ', '0'}, "AB12"},
+		{"interior characters preserved", " A B ", []byte{' '}, "A B"},
+		{"nothing to trim", "AB12", []byte{' '}, "AB12"},
+		{"all trimmed", "   ", []byte{' '}, ""},
+		{"empty string", "", []byte{' '}, ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := TrimAll(test.str, test.trimChars)
+			if got != test.want {
+				t.Errorf("TrimAll(%q, %v) mismatch. Wanted: %q   Got: %q", test.str, test.trimChars, test.want, got)
+			}
+		})
+	}
+}
+
+func Test_SplitBySeparator(t *testing.T) {
+	const sep = byte(0x1C)
+
+	tests := []struct {
+		name string
+		data string
+		want []string
+	}{
+		{"no separator returns empty slice", "AM04", []string{}},
+		{"empty string returns empty slice", "", []string{}},
+		{"content before first separator is dropped", "AM04\x1Cf1\x1Cf2", []string{"f1", "f2"}},
+		{"leading separator", "\x1Cf1\x1Cf2", []string{"f1", "f2"}},
+		{"trailing separator yields empty element", "\x1Cf1\x1C", []string{"f1", ""}},
+		{"consecutive separators yield empty element", "\x1Cf1\x1C\x1Cf2", []string{"f1", "", "f2"}},
+		{"only separator", "\x1C", []string{""}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := SplitBySeparator(test.data, sep)
+			if !slices.Equal(got, test.want) {
+				t.Errorf("SplitBySeparator(%q) mismatch. Wanted: %q   Got: %q", test.data, test.want, got)
+			}
+		})
+	}
+}
+
+func Test_Chunk(t *testing.T) {
+	tests := []struct {
+		name      string
+		str       string
+		chunkSize int
+		want      []string
+	}{
+		{"empty string returns nil", "", 2, nil},
+		{"chunk size equal to length", "abcd", 4, []string{"abcd"}},
+		{"chunk size larger than length", "abcd", 10, []string{"abcd"}},
+		{"even chunks", "abcdef", 2, []string{"ab", "cd", "ef"}},
+		{"uneven final chunk", "abcde", 2, []string{"ab", "cd", "e"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := Chunk(test.str, test.chunkSize)
+			if !slices.Equal(got, test.want) {
+				t.Errorf("Chunk(%q, %v) mismatch. Wanted: %q   Got: %q", test.str, test.chunkSize, test.want, got)
+			}
+		})
+	}
+}
+
+func Test_IndexOfAll(t *testing.T) {
+	tests := []struct {
+		name       string
+		str        string
+		searchTerm string
+		want       []int
+	}{
+		{"multiple matches", "a\x1Eb\x1Ec", "\x1E", []int{1, 3}},
+		{"single match", "abc", "b", []int{1}},
+		{"no match returns empty slice", "abc", "z", []int{}},
+		{"overlapping matches", "aaa", "aa", []int{0, 1}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := IndexOfAll(test.str, test.searchTerm)
+			if !slices.Equal(got, test.want) {
+				t.Errorf("IndexOfAll(%q, %q) mismatch. Wanted: %v   Got: %v", test.str, test.searchTerm, test.want, got)
+			}
+		})
+	}
+}
+
+func Test_IndexAt(t *testing.T) {
+	tests := []struct {
+		name       string
+		str        string
+		searchTerm string
+		startIndex int
+		want       int
+	}{
+		{"match after start index", "abcabc", "abc", 1, 3},
+		{"match at start index", "abcabc", "abc", 3, 3},
+		{"no match after start index", "abcdef", "abc", 1, -1},
+		{"match at zero", "abc", "abc", 0, 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := IndexAt(test.str, test.searchTerm, test.startIndex)
+			if got != test.want {
+				t.Errorf("IndexAt(%q, %q, %v) mismatch. Wanted: %v   Got: %v", test.str, test.searchTerm, test.startIndex, test.want, got)
+			}
+		})
+	}
+}
+
+func Test_SplitFirst(t *testing.T) {
+	const sep = byte(0x1C)
+
+	tests := []struct {
+		name      string
+		str       string
+		fromIndex int
+		want      string
+	}{
+		{"first field", "ab\x1Ccd\x1Cef", 0, "ab"},
+		{"middle field", "ab\x1Ccd\x1Cef", 3, "cd"},
+		{"last field returns remainder", "ab\x1Ccd\x1Cef", 6, "ef"},
+		{"no separator returns remainder", "abcdef", 1, "bcdef"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := SplitFirst(test.str, test.fromIndex, []byte{sep})
+			if got != test.want {
+				t.Errorf("SplitFirst(%q, %v) mismatch. Wanted: %q   Got: %q", test.str, test.fromIndex, test.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Adds F6 parsing and serialization alongside D.0, fully backward compatible (no renames/retypes of existing fields)
- F6 request header (58 bytes) supported via layoutF6 tags; response header is unchanged (identical to D0)
- New F6 fields across request/response segments plus new segments (intermediary, lastKnown4Rx, nTransactionPayerIdentification, otherRelatedBenefitDetail, provider); ncpdp-schemas.json updated to match
- F6 (vEB+) has no group separators and allows exactly one transaction per transmission: the deserializer locates the claim group by segment ID, and the serializer omits the group separator and rejects multiple claim groups
- Fields that are singular in D0 but repeat in F6 are dual-mapped (existing scalar + parallel slice) so no data is lost and existing callers are unaffected

## Test plan
- [x] F6 header parse/build tests (pkg/ncpdp/header_test.go)
- [x] End-to-end parse of a full-field raw F6 billing request (Test_CanParseF6FullFieldSample)
- [x] Round-trip tests asserting no group separators in F6 output
- [x] Serializer rejects multiple claim groups for F6 (Test_F6SerializeRejectsMultipleClaimGroups)
- [x] Boundary cases: F6 with only shared segments; unknown segments before/after the claim-group boundary
- [x] Full suite green: go test ./pkg/claimDeserializer ./pkg/claimSerializer ./pkg/ncpdp