### PR TITLE
fix(scan): empty field returned remainder of transmission

### DIFF
--- a/pkg/ncpdp/transaction.go
+++ b/pkg/ncpdp/transaction.go
@@ -446,7 +446,11 @@ func (tran *NcpdpTransaction[V]) ScanRawDataForFieldValues(fieldCode string) []s
 		strValue := stringutils.Substring(tran.RawValue, startIndex, -1)
 		endIndex := stringutils.IndexOfAny(strValue, 0, []byte{FIELD, SEGMENT, GROUP, ETX})
 
-		if endIndex > 0 {
+		// endIndex == 0 means the field is empty (a separator immediately follows the
+		// field code) — without this case an empty field returned the remainder of the
+		// transmission, control characters and all. endIndex < 0 means no separator
+		// follows, so the value runs to the end of the raw data.
+		if endIndex >= 0 {
 			strValue = stringutils.Substring(strValue, 0, endIndex)
 		}
 

--- a/pkg/ncpdp/transaction_scan_test.go
+++ b/pkg/ncpdp/transaction_scan_test.go
@@ -1,0 +1,83 @@
+package ncpdp
+
+import (
+	"testing"
+)
+
+// TestScanRawDataForFieldValues_EmptyField is a regression test: an EMPTY field
+// (field code immediately followed by another separator) must return "" — not the
+// remainder of the transmission. Before the endIndex >= 0 fix, an empty CM field
+// returned "\x1cCNMIAMI..." (control chars + every following field), which
+// manufactured garbage values in downstream consumers.
+func TestScanRawDataForFieldValues_EmptyField(t *testing.T) {
+	fs := string(FIELD)
+	ss := string(SEGMENT)
+	gs := string(GROUP)
+	etx := string(ETX)
+
+	tests := []struct {
+		name     string
+		rawValue string
+		field    string
+		want     []string
+	}{
+		{
+			name:     "empty field followed by another field",
+			rawValue: fs + "CM" + fs + "CN" + "MIAMI",
+			field:    "CM",
+			want:     []string{""},
+		},
+		{
+			name:     "empty field at segment boundary",
+			rawValue: fs + "CM" + ss + fs + "CP" + "33101",
+			field:    "CM",
+			want:     []string{""},
+		},
+		{
+			name:     "empty field at group boundary",
+			rawValue: fs + "CQ" + gs + fs + "D7" + "00000000001",
+			field:    "CQ",
+			want:     []string{""},
+		},
+		{
+			name:     "empty field before ETX",
+			rawValue: fs + "CP" + etx,
+			field:    "CP",
+			want:     []string{""},
+		},
+		{
+			name:     "non-empty field is unaffected",
+			rawValue: fs + "CM" + "123 MAIN ST" + fs + "CN" + "MIAMI",
+			field:    "CM",
+			want:     []string{"123 MAIN ST"},
+		},
+		{
+			name:     "field at end of raw data with no trailing separator",
+			rawValue: fs + "CM" + "123 MAIN ST",
+			field:    "CM",
+			want:     []string{"123 MAIN ST"},
+		},
+		{
+			name:     "repeating field with one empty occurrence",
+			rawValue: fs + "MJ" + "GROUP1" + fs + "MJ" + fs + "MJ" + "GROUP3",
+			field:    "MJ",
+			want:     []string{"GROUP1", "", "GROUP3"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tran := NcpdpTransaction[RequestHeader]{RawValue: tc.rawValue}
+			got := tran.ScanRawDataForFieldValues(tc.field)
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("value count mismatch. Wanted: %d  Got: %d (%q)", len(tc.want), len(got), got)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("value %d mismatch. Wanted: %q  Got: %q", i, tc.want[i], got[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`ScanRawDataForFieldValues` (pkg/ncpdp/transaction.go) used `if endIndex > 0` to decide whether to truncate the scanned value at the next separator. When a field is **empty** (its code is immediately followed by another separator), `IndexOfAny` returns `0`, the condition was false, and the returned "value" was the **entire remainder of the raw transmission** — NCPDP control characters (0x1C/0x1D/0x1E) and every following field included.

This actively manufactures garbage downstream: the MPI feeder calls this scanner for street/zip/phone (CM/CP/CQ), so any claim with an empty one of those fields produced a 0x1C-blob value that ended up in the Master Patient Index.

## Fix

One character: `endIndex >= 0`. `endIndex == 0` now yields `""`; `endIndex < 0` (no separator — field runs to the end of the data) keeps the remainder as before.

## Tests

New regression test `TestScanRawDataForFieldValues_EmptyField` covers empty fields at field/segment/group/ETX boundaries, repeating fields with one empty occurrence, and the unaffected non-empty/end-of-data cases. Verified the test fails on the previous code (returned values like `\x1cMJGROUP3`, `\x1d\x1cD700000000001") and passes with the fix. Full `go test ./...` passes.

## Release

Merging Development → Production auto-tags the next patch release (release.yml); the MPI feeder pin bump to that tag follows in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)