### PR TITLE
Add beta prerelease workflow for Development builds

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,34 @@
+on:
+  push:
+    branches:
+      - Development
+
+jobs:
+  prerelease-on-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Compute next beta version
+        id: version
+        run: |
+          latest=$(git tag --list 'v*' --sort=-v:refname | grep -v -- '-beta\.' | head -n 1 || true)
+          latest=${latest:-v0.0.0}
+          IFS=. read -r major minor patch <<< "${latest#v}"
+          next="v${major}.${minor}.$((patch+1))"
+          count=$(git tag --list "${next}-beta.*" | wc -l)
+          echo "tag=${next}-beta.$((count+1))" >> "$GITHUB_OUTPUT"
+
+      - name: Create prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --prerelease \
+            --generate-notes \
+            --target "$GITHUB_SHA" \
+            --title "${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
Pushes to Development now create a v<next-patch>-beta.N prerelease tag so consumers can pull pre-production builds without affecting the Production release flow.