### PR TITLE
Document D0/F6 dual support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # NCPDP Serializer/Deserializer
 
 ## Overview
-Parse and build NCPDP claims.
+Parse and build NCPDP telecommunication claims. Supports **D.0** and **F6** (vF6) formats — the version is auto-detected from the header on parse, and selected from the `Version` field on build. No format flags needed.
+
+> **Migrating an existing app to F6?** See [F6_MIGRATION.md](F6_MIGRATION.md) — especially the warning about `tran.Records[0]` being empty for F6.
 
 ### Parse Examples (Generic Parser)
 Request:
@@ -72,3 +74,88 @@ request.Records = append(request.Records, claimRecord)
 
 err := request.BuildNcpdp()
 ```
+
+Build an **F6** Request (single transaction, no group separator):
+```go
+request := ncpdp.NewTransactionRequest("")
+
+// Populate header — version "F6" drives the F6 layout and omits 0x1D on build
+request.Header.Value.Version = ncpdp.F6
+request.Header.Value.TransactionCode = ncpdp.BILLING
+request.Header.Value.Bin = "88015600" // 101-A1 IIN in F6 is 8 chars
+request.Header.Value.Pcn = "PCN1234567"
+request.Header.Value.RecordCount = 1
+request.Header.Value.ServiceProviderIdQualifier = "01"
+request.Header.Value.ServiceProviderId = "1234567893"
+request.Header.Value.DateOfService = "20260611"
+request.Header.Value.SoftwareVendorCertificationId = "VENDORCERT"
+
+// F6 allows exactly one transaction per transmission; BuildNcpdp errors on >1.
+claimRecord := ncpdp.NcpdpRecord{}
+// ... populate claimRecord.Segments ...
+request.Records = append(request.Records, claimRecord)
+
+err := request.BuildNcpdp()
+```
+
+### ⚠️ Records vs. Segments on F6
+For the generic parser, F6 transmissions have **no group separator (`0x1D`)**, so all segments land in `tran.Segments` and `tran.Records` stays **empty**. Direct indexing like `tran.Records[0]` will misbehave or panic on F6.
+
+Use the F6-safe helpers instead — they fall back to shared segments when `Records` is empty, so the same code works for both D0 and F6:
+```go
+// ✅ Works for both D0 and F6
+seg := tran.FindSegmentInRecord(0, ncpdp.RESPONSE_STATUS_SEGMENT_ID)
+for i := 0; i < tran.RecordCount(); i++ {
+    seg := tran.FindSegmentInRecord(i, ncpdp.CLAIM_SEGMENT_ID)
+    ...
+}
+```
+
+### Response Helpers
+Convenience methods on `NcpdpTransaction[ResponseHeader]` — all F6-aware:
+```go
+responseTran := ncpdp.NewTransactionResponse(rawClaimString)
+_ = responseTran.ParseNcpdp()
+
+status := responseTran.Status()             // "P", "R", "D", etc.
+isPaid := responseTran.IsPaid()             // P or D
+isRejected := responseTran.IsRejected()     // R
+rejectCodes := responseTran.GetRejectCodes() // []string from FB fields
+messages := responseTran.GetAdditionalMessages() // map[qualifier]message from UH/FQ pairs
+```
+
+### Strongly-Typed Parser/Builder
+For type-safe access to NCPDP fields (vs. iterating raw segments), use the `claimDeserializer` / `claimSerializer` packages. They return concrete request/response structs (`request.BillingRequest`, `response.BillingResponse`, etc.) with typed fields, support both D0 and F6, and round-trip cleanly.
+
+Deserialize:
+```go
+import "github.com/transactrx/NCPDPSerDe/pkg/claimDeserializer"
+
+obj, err := claimDeserializer.DeserializeRequest(rawClaimString)
+billing, ok := obj.(*request.BillingRequest)
+if ok {
+    rxNumber := billing.Claims[0].Claim.PrescriptionServiceReferenceNo
+    // F6: Claims[0] is still populated — the strongly-typed parser locates the
+    // single transaction by segment ID when no group separator is present.
+}
+```
+
+Serialize:
+```go
+import "github.com/transactrx/NCPDPSerDe/pkg/claimSerializer"
+
+raw, err := claimSerializer.Serialize(billing)
+// Header version drives format: "D0" emits 0x1D group separators,
+// "F6" omits them and errors if more than one claim group is present.
+```
+
+### Repeating Fields (CX/CY, J7/J8) on F6
+F6 permits patient IDs (CX/CY) and insurance payers (J7/J8) to repeat. The strongly-typed structs expose both shapes for backward compatibility:
+
+| Segment | Scalar (D0, preserved) | Slice (F6 repeats) |
+|---|---|---|
+| `request.Patient` | `IdQualifier`, `Id` | `Ids []PatientId` |
+| `response.Insurance` | `Payer` | `Payers []Payer` |
+
+- **Reading:** scalar holds the last occurrence; slice holds every occurrence. Read the slice when full F6 data matters.
+- **Writing:** when the slice is non-empty, the serializer skips the scalar's codes to prevent double-emit. Populate one or the other.


### PR DESCRIPTION
Adds F6 build example, the Records[0] gotcha with the safe-helper pattern, response helper usage, the strongly-typed serializer package examples, and the dual scalar/slice mapping for CX/CY and J7/J8 repeating fields. Links to F6_MIGRATION.md.