### PR TITLE
Fix JSON round-trip serialization panic 

### DIFF
--- a/pkg/claimDeserializer/claimDeserializer.go
+++ b/pkg/claimDeserializer/claimDeserializer.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/transactrx/NCPDPSerDe/pkg/dynamic"
@@ -540,8 +541,12 @@ func setStructFieldByCodeTag(structType reflect.Type, structVal reflect.Value, c
 			sliceLen := f.Len()
 			sliceItemType := f.Type().Elem()
 
-			// Create new slice element
-			if sliceLen <= repeatingFieldIndex {
+			// Create new slice element. Only grow this slice when the element
+			// type owns the field code directly; a repeating code that lives in
+			// a deeper nested slice (e.g. a second 6E reject within a single
+			// other payer) must repeat inside the last element instead of
+			// splitting it into a new occurrence of this slice.
+			if sliceLen <= repeatingFieldIndex && (sliceLen == 0 || isDynamic || typeOwnsCode(sliceItemType, codeTag)) {
 				sliceItem := reflect.New(sliceItemType).Elem()
 
 				// Initialize element
@@ -588,6 +593,58 @@ func setStructFieldByCodeTag(structType reflect.Type, structVal reflect.Value, c
 	}
 
 	return setCount
+}
+
+type typeCodeKey struct {
+	structType reflect.Type
+	code       string
+}
+
+var typeOwnsCodeCache sync.Map
+
+// typeOwnsCode reports whether a struct type has a field with the given code
+// tag on the type itself (including embedded structs), excluding fields that
+// belong to nested slice element types.
+func typeOwnsCode(structType reflect.Type, codeTag string) bool {
+	if structType.Kind() != reflect.Struct {
+		return false
+	}
+
+	key := typeCodeKey{structType: structType, code: codeTag}
+	if cached, ok := typeOwnsCodeCache.Load(key); ok {
+		return cached.(bool)
+	}
+
+	owns := false
+
+	for i := 0; i < structType.NumField(); i++ {
+		ft := structType.Field(i)
+
+		switch ft.Type.Kind() {
+		case reflect.Struct:
+			owns = typeOwnsCode(ft.Type, codeTag)
+
+		case reflect.Slice:
+			// Nested slice fields are owned by their own element type.
+
+		default:
+			tag := ft.Tag.Get(serde.FieldTag)
+			if tag != serde.Empty {
+				attr, err := serde.GetFieldAttribute(tag)
+				if err == nil && attr.Code == codeTag {
+					owns = true
+				}
+			}
+		}
+
+		if owns {
+			break
+		}
+	}
+
+	typeOwnsCodeCache.Store(key, owns)
+
+	return owns
 }
 
 // Set base field by data type.

--- a/pkg/claimDeserializer/claimDeserializer_test.go
+++ b/pkg/claimDeserializer/claimDeserializer_test.go
@@ -535,6 +535,45 @@ func Test_CanParseUndefinedReversalSegments(t *testing.T) {
 	}
 }
 
+// Repeating fields that belong to a nested slice (e.g. multiple 6E reject
+// codes for one other payer) must repeat within the same parent occurrence
+// instead of splitting the parent into additional occurrences. REQUEST_B1's
+// COB segment carries 4C1 (one payer) with 5E02/6E70/6EA5 (two rejects) and
+// HB1/HC/DV (one amount paid).
+func Test_NestedRepeatingFieldsStayInParentOccurrence(t *testing.T) {
+	obj := request.Billing{}
+	if err := DeserializeType(REQUEST_B1, &obj); err != nil {
+		t.Fatal(err)
+	}
+
+	cob := obj.Claims[0].CoordinationOfBenefits
+
+	if cob.Count == nil || *cob.Count != 1 {
+		t.Fatalf("COB count (4C) mismatch. Wanted: 1   Got: %v", cob.Count)
+	}
+
+	if len(cob.OtherPayer) != 1 {
+		t.Fatalf("OtherPayer count mismatch. Wanted: 1   Got: %v", len(cob.OtherPayer))
+	}
+
+	payer := cob.OtherPayer[0]
+
+	if len(payer.OtherPayerRejects) != 2 {
+		t.Fatalf("OtherPayerRejects count mismatch. Wanted: 2   Got: %v", len(payer.OtherPayerRejects))
+	}
+
+	for i, want := range []string{"70 ", "A5 "} {
+		got := payer.OtherPayerRejects[i].RejectCode
+		if got == nil || *got != want {
+			t.Errorf("Reject code %v mismatch. Wanted: %q   Got: %v", i, want, got)
+		}
+	}
+
+	if len(payer.OtherPayerAmountsPaid) != 1 {
+		t.Errorf("OtherPayerAmountsPaid count mismatch. Wanted: 1   Got: %v", len(payer.OtherPayerAmountsPaid))
+	}
+}
+
 // F6 request header is 58 bytes: version(2) tranCode(2) IIN(8) PCN(10) recordCount(1) SPIQ(2) SPI(15) DOS(8) vendorCertId(10)
 const F6_REQUEST_B1_HEADER = "F6B100880151TEST      1011234567893     20260611SVCID     "
 

--- a/pkg/claimSerializer/claimSerializer.go
+++ b/pkg/claimSerializer/claimSerializer.go
@@ -187,6 +187,9 @@ func buildSegment(structType reflect.Type, structVal reflect.Value, segmentCode 
 	switch baseVal.Interface().(type) {
 	case dynamic.DynamicStruct:
 		ds, _ := baseVal.Interface().(dynamic.DynamicStruct)
+		if ds.DynamicType == nil || ds.Value == nil {
+			return serde.Empty, fmt.Errorf("dynamic segment is missing type information and cannot be serialized")
+		}
 		baseType = reflectionutils.GetElementType(ds.DynamicType)
 		baseVal = reflectionutils.GetElementValue(reflect.ValueOf(ds.Value))
 	}
@@ -261,6 +264,9 @@ func buildFieldMap(structType reflect.Type, structVal reflect.Value, skipCodes m
 	switch baseVal.Interface().(type) {
 	case dynamic.DynamicStruct:
 		ds, _ := baseVal.Interface().(dynamic.DynamicStruct)
+		if ds.DynamicType == nil || ds.Value == nil {
+			return nil, fmt.Errorf("dynamic field is missing type information and cannot be serialized")
+		}
 		baseType = reflectionutils.GetElementType(ds.DynamicType)
 		baseVal = reflectionutils.GetElementValue(reflect.ValueOf(ds.Value))
 	}

--- a/pkg/claimSerializer/jsonRoundTrip_test.go
+++ b/pkg/claimSerializer/jsonRoundTrip_test.go
@@ -36,6 +36,16 @@ func serializeConcrete(i any) (string, error) {
 	}
 }
 
+// unmarshalAndSerialize unmarshals a claim's JSON into a fresh struct of the
+// given concrete type and serializes the result.
+func unmarshalAndSerialize[V any](jsonBytes []byte) (string, error) {
+	fresh := new(V)
+	if err := json.Unmarshal(jsonBytes, fresh); err != nil {
+		return "", err
+	}
+	return Serialize(fresh)
+}
+
 // jsonRoundTripSerialize marshals a deserialized claim to JSON, unmarshals it
 // into a fresh struct of the same concrete type, and serializes the result.
 func jsonRoundTripSerialize(i any) (string, error) {
@@ -46,53 +56,21 @@ func jsonRoundTripSerialize(i any) (string, error) {
 
 	switch i.(type) {
 	case request.Billing:
-		fresh := request.Billing{}
-		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
-			return "", err
-		}
-		return Serialize(&fresh)
+		return unmarshalAndSerialize[request.Billing](jsonBytes)
 	case request.Reversal:
-		fresh := request.Reversal{}
-		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
-			return "", err
-		}
-		return Serialize(&fresh)
+		return unmarshalAndSerialize[request.Reversal](jsonBytes)
 	case request.Rebill:
-		fresh := request.Rebill{}
-		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
-			return "", err
-		}
-		return Serialize(&fresh)
+		return unmarshalAndSerialize[request.Rebill](jsonBytes)
 	case request.Eligibility:
-		fresh := request.Eligibility{}
-		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
-			return "", err
-		}
-		return Serialize(&fresh)
+		return unmarshalAndSerialize[request.Eligibility](jsonBytes)
 	case response.Billing:
-		fresh := response.Billing{}
-		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
-			return "", err
-		}
-		return Serialize(&fresh)
+		return unmarshalAndSerialize[response.Billing](jsonBytes)
 	case response.Reversal:
-		fresh := response.Reversal{}
-		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
-			return "", err
-		}
-		return Serialize(&fresh)
+		return unmarshalAndSerialize[response.Reversal](jsonBytes)
 	case response.Rebill:
-		fresh := response.Rebill{}
-		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
-			return "", err
-		}
-		return Serialize(&fresh)
+		return unmarshalAndSerialize[response.Rebill](jsonBytes)
 	case response.Eligibility:
-		fresh := response.Eligibility{}
-		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
-			return "", err
-		}
-		return Serialize(&fresh)
+		return unmarshalAndSerialize[response.Eligibility](jsonBytes)
 	default:
 		return "", fmt.Errorf("unknown type %T", i)
 	}

--- a/pkg/claimSerializer/jsonRoundTrip_test.go
+++ b/pkg/claimSerializer/jsonRoundTrip_test.go
@@ -1,0 +1,160 @@
+package claimserializer
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	claimdeserializer "github.com/transactrx/NCPDPSerDe/pkg/claimDeserializer"
+	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp"
+	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp/request"
+	"github.com/transactrx/NCPDPSerDe/pkg/ncpdp/response"
+)
+
+// serializeConcrete serializes a deserialized claim of any supported concrete type.
+func serializeConcrete(i any) (string, error) {
+	switch item := i.(type) {
+	case request.Billing:
+		return Serialize(&item)
+	case request.Reversal:
+		return Serialize(&item)
+	case request.Rebill:
+		return Serialize(&item)
+	case request.Eligibility:
+		return Serialize(&item)
+	case response.Billing:
+		return Serialize(&item)
+	case response.Reversal:
+		return Serialize(&item)
+	case response.Rebill:
+		return Serialize(&item)
+	case response.Eligibility:
+		return Serialize(&item)
+	default:
+		return "", fmt.Errorf("unknown type %T", i)
+	}
+}
+
+// jsonRoundTripSerialize marshals a deserialized claim to JSON, unmarshals it
+// into a fresh struct of the same concrete type, and serializes the result.
+func jsonRoundTripSerialize(i any) (string, error) {
+	jsonBytes, err := json.Marshal(i)
+	if err != nil {
+		return "", err
+	}
+
+	switch i.(type) {
+	case request.Billing:
+		fresh := request.Billing{}
+		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
+			return "", err
+		}
+		return Serialize(&fresh)
+	case request.Reversal:
+		fresh := request.Reversal{}
+		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
+			return "", err
+		}
+		return Serialize(&fresh)
+	case request.Rebill:
+		fresh := request.Rebill{}
+		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
+			return "", err
+		}
+		return Serialize(&fresh)
+	case request.Eligibility:
+		fresh := request.Eligibility{}
+		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
+			return "", err
+		}
+		return Serialize(&fresh)
+	case response.Billing:
+		fresh := response.Billing{}
+		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
+			return "", err
+		}
+		return Serialize(&fresh)
+	case response.Reversal:
+		fresh := response.Reversal{}
+		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
+			return "", err
+		}
+		return Serialize(&fresh)
+	case response.Rebill:
+		fresh := response.Rebill{}
+		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
+			return "", err
+		}
+		return Serialize(&fresh)
+	case response.Eligibility:
+		fresh := response.Eligibility{}
+		if err := json.Unmarshal(jsonBytes, &fresh); err != nil {
+			return "", err
+		}
+		return Serialize(&fresh)
+	default:
+		return "", fmt.Errorf("unknown type %T", i)
+	}
+}
+
+// A claim that went through a JSON round-trip must serialize identically to
+// the original deserialized claim. Dynamic segments and fields lose their
+// generated reflect.Type in JSON (DynamicType is json:"-"); DynamicStruct's
+// UnmarshalJSON reconstructs it from the encoded field names.
+func Test_CanSerializeAfterJsonRoundTrip(t *testing.T) {
+	tests := append(append([]serializerTest{}, dynamicTests...), extraSegmentsRequestTests...)
+
+	for _, test := range tests {
+		i, err := claimdeserializer.Deserialize(test.rawData)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		direct, err := serializeConcrete(i)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		roundTripped, err := jsonRoundTripSerialize(i)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		if roundTripped != direct {
+			t.Errorf("JSON round-trip serialization mismatch.\nWanted: %q\nGot:    %q", direct, roundTripped)
+		}
+	}
+}
+
+// A single other payer with multiple rejects must re-serialize with the
+// original payer count (4C) and reject count (5E) instead of being split
+// into multiple payer occurrences.
+func Test_SerializePreservesNestedRepeatingGroups(t *testing.T) {
+	obj := request.Billing{}
+	if err := claimdeserializer.DeserializeType(REQUEST_B1, &obj); err != nil {
+		t.Fatal(err)
+	}
+
+	serialized, err := Serialize(&obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fs := string(ncpdp.FIELD)
+
+	for _, want := range []string{
+		fs + "4C1" + fs,
+		fs + "5E2" + fs + "6E70 " + fs + "6EA5 ",
+	} {
+		if !strings.Contains(serialized, want) {
+			t.Errorf("serialized COB segment missing %q", want)
+		}
+	}
+
+	assertFieldCount(t, serialized, "5C", 1)
+	assertFieldCount(t, serialized, "5E", 1)
+}

--- a/pkg/dynamic/dynamic.go
+++ b/pkg/dynamic/dynamic.go
@@ -1,14 +1,214 @@
 package dynamic
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
+	"strconv"
 	"strings"
 )
 
 type DynamicStruct struct {
 	DynamicType reflect.Type `json:"-"`
 	Value       *any
+}
+
+// Field name of the raw-data field included in dynamic segment types.
+const rawFieldName = "Raw"
+
+// Field name prefix for dynamically generated fields.
+const fieldNamePrefix = "Field_"
+
+var illegalNamingRunes = map[rune]string{
+	'!':  "exclamation",
+	'"':  "quote",
+	'#':  "hash",
+	'$':  "dollar",
+	'&':  "ampersand",
+	'\'': "apostrophe",
+	'(':  "leftparenthesis",
+	')':  "rightparenthesis",
+	'*':  "asterisk",
+	',':  "comma",
+	':':  "colon",
+	';':  "semicolon",
+	'<':  "lessthan",
+	'=':  "equals",
+	'>':  "greaterthan",
+	'?':  "questionmark",
+	'[':  "leftbracket",
+	'\\': "backslash",
+	']':  "rightbracket",
+	'^':  "caret",
+	'`':  "backtick",
+	'{':  "leftbrace",
+	'|':  "pipe",
+	'}':  "rightbrace",
+}
+
+// FieldName builds the struct field name for a dynamically generated field.
+func FieldName(fieldCode string, order int) string {
+	return fieldNamePrefix + ReplaceIllegalCharacters(fieldCode) + "_" + strconv.Itoa(order)
+}
+
+// ReplaceIllegalCharacters replaces characters that are invalid in Go
+// identifiers with word equivalents.
+func ReplaceIllegalCharacters(str string) string {
+	builder := strings.Builder{}
+
+	for _, ch := range str {
+		val, found := illegalNamingRunes[ch]
+		if found {
+			builder.WriteString(val)
+		} else {
+			builder.WriteRune(ch)
+		}
+	}
+
+	return builder.String()
+}
+
+// restoreIllegalCharacters reverses ReplaceIllegalCharacters by matching the
+// longest word equivalent at each position.
+func restoreIllegalCharacters(mangled string) string {
+	builder := strings.Builder{}
+
+	for len(mangled) > 0 {
+		matchedRune, matchedLen := rune(0), 0
+		for ch, word := range illegalNamingRunes {
+			if len(word) > matchedLen && strings.HasPrefix(mangled, word) {
+				matchedRune, matchedLen = ch, len(word)
+			}
+		}
+
+		if matchedLen > 0 {
+			builder.WriteRune(matchedRune)
+			mangled = mangled[matchedLen:]
+			continue
+		}
+
+		r := []rune(mangled)
+		builder.WriteRune(r[0])
+		mangled = string(r[1:])
+	}
+
+	return builder.String()
+}
+
+// parseFieldName extracts the field code and order encoded in a dynamically
+// generated field name (see FieldName).
+func parseFieldName(name string) (code string, order int, ok bool) {
+	if !strings.HasPrefix(name, fieldNamePrefix) {
+		return "", 0, false
+	}
+
+	rest := name[len(fieldNamePrefix):]
+	sep := strings.LastIndex(rest, "_")
+	if sep < 0 {
+		return "", 0, false
+	}
+
+	order, err := strconv.Atoi(rest[sep+1:])
+	if err != nil {
+		return "", 0, false
+	}
+
+	return restoreIllegalCharacters(rest[:sep]), order, true
+}
+
+// UnmarshalJSON rebuilds DynamicType and a typed Value from JSON produced by
+// marshaling a DynamicStruct. DynamicType is excluded from the JSON (json:"-"),
+// so it is reconstructed from the field names, which encode each field's code
+// and order. Without this, a JSON round-trip leaves DynamicType nil and the
+// struct cannot be serialized back to NCPDP format.
+func (d *DynamicStruct) UnmarshalJSON(data []byte) error {
+	var wrapper struct {
+		Value json.RawMessage
+	}
+
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return err
+	}
+
+	d.DynamicType = nil
+	d.Value = nil
+
+	if len(wrapper.Value) == 0 || string(wrapper.Value) == "null" {
+		return nil
+	}
+
+	var rawFields map[string]*string
+	if err := json.Unmarshal(wrapper.Value, &rawFields); err != nil {
+		// Not the flat string object a dynamic segment/field marshals to;
+		// preserve the value untyped.
+		var v any
+		if err := json.Unmarshal(wrapper.Value, &v); err != nil {
+			return err
+		}
+		d.Value = &v
+		return nil
+	}
+
+	type fieldEntry struct {
+		structField reflect.StructField
+		value       *string
+		order       int
+	}
+
+	entries := []fieldEntry{}
+
+	for name, value := range rawFields {
+		if name == rawFieldName {
+			entries = append(entries, fieldEntry{
+				structField: reflect.StructField{
+					Name: rawFieldName,
+					Type: reflect.TypeOf((*string)(nil)),
+					Tag:  `field:"code=rawsegment"`,
+				},
+				value: value,
+				order: 0,
+			})
+			continue
+		}
+
+		code, order, ok := parseFieldName(name)
+		if !ok {
+			continue
+		}
+
+		entries = append(entries, fieldEntry{
+			structField: reflect.StructField{
+				Name: name,
+				Type: reflect.TypeOf((*string)(nil)),
+				Tag:  reflect.StructTag(fmt.Sprintf(`field:"code=%v,order=%v"`, code, order)),
+			},
+			value: value,
+			order: order,
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].order < entries[j].order })
+
+	structFields := make([]reflect.StructField, 0, len(entries))
+	for _, entry := range entries {
+		structFields = append(structFields, entry.structField)
+	}
+
+	dynamicType := reflect.StructOf(structFields)
+	dynamicValue := reflect.New(dynamicType).Elem()
+
+	for i, entry := range entries {
+		if entry.value != nil {
+			dynamicValue.Field(i).Set(reflect.ValueOf(entry.value))
+		}
+	}
+
+	iface := dynamicValue.Interface()
+	d.DynamicType = dynamicType
+	d.Value = &iface
+
+	return nil
 }
 
 type DynamicFieldData struct {

--- a/pkg/dynamic/dynamic_test.go
+++ b/pkg/dynamic/dynamic_test.go
@@ -1,0 +1,118 @@
+package dynamic
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func Test_ReplaceIllegalCharactersRoundTrip(t *testing.T) {
+	codes := []string{"&B", "#A", "!F", "AD", "S4", "{X", "=Y", "[D", "c4", "__"}
+
+	for _, code := range codes {
+		mangled := ReplaceIllegalCharacters(code)
+		if got := restoreIllegalCharacters(mangled); got != code {
+			t.Errorf("restoreIllegalCharacters(%q) mismatch. Wanted: %q   Got: %q", mangled, code, got)
+		}
+	}
+}
+
+func Test_FieldNameParseRoundTrip(t *testing.T) {
+	for _, test := range []struct {
+		code  string
+		order int
+	}{
+		{code: "&B", order: 25},
+		{code: "#A", order: 1},
+		{code: "AD", order: 100},
+	} {
+		name := FieldName(test.code, test.order)
+		code, order, ok := parseFieldName(name)
+		if !ok || code != test.code || order != test.order {
+			t.Errorf("parseFieldName(%q) mismatch. Wanted: (%q, %v)   Got: (%q, %v, %v)", name, test.code, test.order, code, order, ok)
+		}
+	}
+}
+
+// UnmarshalJSON must rebuild DynamicType and a typed Value so a DynamicStruct
+// that went through a JSON round-trip can still be serialized.
+func Test_DynamicStructJsonRoundTrip(t *testing.T) {
+	raw := "AMXX&BTEST#A3"
+	segId := "AMXX"
+	code1 := "TEST"
+	code2 := "3"
+
+	original := struct {
+		Raw                *string `field:"code=rawsegment"`
+		Field_AM_1         *string `field:"code=AM,order=1"`
+		Field_ampersandB_2 *string `field:"code=&B,order=2"`
+		Field_hashA_3      *string `field:"code=#A,order=3"`
+	}{
+		Raw:                &raw,
+		Field_AM_1:         &segId,
+		Field_ampersandB_2: &code1,
+		Field_hashA_3:      &code2,
+	}
+
+	var iface any = original
+	ds := DynamicStruct{DynamicType: reflect.TypeOf(original), Value: &iface}
+
+	jsonBytes, err := json.Marshal(ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rebuilt := DynamicStruct{}
+	if err := json.Unmarshal(jsonBytes, &rebuilt); err != nil {
+		t.Fatal(err)
+	}
+
+	if rebuilt.DynamicType == nil {
+		t.Fatal("DynamicType not reconstructed")
+	}
+
+	if rebuilt.Value == nil {
+		t.Fatal("Value not reconstructed")
+	}
+
+	rebuiltVal := reflect.ValueOf(*rebuilt.Value)
+
+	for _, want := range []struct {
+		name  string
+		code  string
+		value string
+	}{
+		{name: "Raw", code: "rawsegment", value: raw},
+		{name: "Field_AM_1", code: "AM", value: segId},
+		{name: "Field_ampersandB_2", code: "&B", value: code1},
+		{name: "Field_hashA_3", code: "#A", value: code2},
+	} {
+		field, ok := rebuilt.DynamicType.FieldByName(want.name)
+		if !ok {
+			t.Errorf("field %v missing from reconstructed type", want.name)
+			continue
+		}
+
+		tag := field.Tag.Get("field")
+		if tag != "code="+want.code && !hasCodeAndOrder(tag, want.code) {
+			t.Errorf("field %v tag mismatch. Got: %q", want.name, tag)
+		}
+
+		fieldVal := rebuiltVal.FieldByName(want.name)
+		if fieldVal.IsNil() {
+			t.Errorf("field %v value is nil", want.name)
+			continue
+		}
+
+		if got := fieldVal.Elem().String(); got != want.value {
+			t.Errorf("field %v value mismatch. Wanted: %q   Got: %q", want.name, want.value, got)
+		}
+	}
+}
+
+// hasCodeAndOrder reports whether a field tag starts with the expected code
+// followed by an order component (e.g. "code=&B,order=2").
+func hasCodeAndOrder(tag, code string) bool {
+	prefix := "code=" + code + ",order="
+	return len(tag) > len(prefix) && tag[:len(prefix)] == prefix
+}

--- a/pkg/ncpdp/schemas/README.md
+++ b/pkg/ncpdp/schemas/README.md
@@ -116,7 +116,7 @@ Repeating-group count fields (e.g. `Count` 4C in Coordination of Benefits, `Reje
 Most fields are nullable (can be omitted or set to null). Only required fields in the schema must be provided.
 
 ### DynamicFields
-Each segment includes a `DynamicFields` array for non-standard or vendor-specific fields.
+Each segment includes a `DynamicFields` array for non-standard or vendor-specific fields; transactions and claim groups likewise include a `DynamicSegments` array for segments not defined in the standard. Both marshal as objects of the form `{"Value": {...}}`, where each key of the inner object encodes the NCPDP field code and its position within the segment as `Field_<code>_<order>` (characters not valid in identifiers are replaced with words, e.g. `Field_ampersandB_25` for code `&B`). Dynamic segments also carry a `Raw` key holding the raw segment capture. These names are how dynamic data survives a JSON round-trip: unmarshaling reconstructs the underlying dynamic type from them, so a JSON payload containing dynamic fields or segments can be serialized back to NCPDP format. Keep the generated key names intact when editing such payloads.
 
 ## Usage Examples
 

--- a/pkg/serde/serde.go
+++ b/pkg/serde/serde.go
@@ -63,33 +63,6 @@ var Formats = map[string]string{
 	"HHmm":     "1504",
 }
 
-var illegalNamingRunes = map[rune]string{
-	'!':  "exclamation",
-	'"':  "quote",
-	'#':  "hash",
-	'$':  "dollar",
-	'&':  "ampersand",
-	'\'': "apostrophe",
-	'(':  "leftparenthesis",
-	')':  "rightparenthesis",
-	'*':  "asterisk",
-	',':  "comma",
-	':':  "colon",
-	';':  "semicolon",
-	'<':  "lessthan",
-	'=':  "equals",
-	'>':  "greaterthan",
-	'?':  "questionmark",
-	'[':  "leftbracket",
-	'\\': "backslash",
-	']':  "rightbracket",
-	'^':  "caret",
-	'`':  "backtick",
-	'{':  "leftbrace",
-	'|':  "pipe",
-	'}':  "rightbrace",
-}
-
 const (
 	Empty           = ""
 	FieldTag        = "field"
@@ -483,23 +456,7 @@ func GetDynamicSlice(tType reflect.Type, tagType string) (*reflect.StructField, 
 // Create dynamic field name. Handle repeating fields by
 // including the element index within the name.
 func DynamicFieldName(fieldCode string, order int) string {
-	return "Field_" + replaceIllegalCharacters(fieldCode) + "_" + strconv.Itoa(order)
-}
-
-// Replace illegal characters in field names.
-func replaceIllegalCharacters(str string) string {
-	builder := strings.Builder{}
-
-	for _, ch := range str {
-		val, found := illegalNamingRunes[ch]
-		if found {
-			builder.WriteString(val)
-		} else {
-			builder.WriteRune(ch)
-		}
-	}
-
-	return builder.String()
+	return dynamic.FieldName(fieldCode, order)
 }
 
 // Create dynamic segment type.


### PR DESCRIPTION
Fix JSON round-trip serialization panic and nested repeating-group spitting

Two bugs surfaced by cross-implementation parity testing:

1. Serializing a claim that went through a JSON round-trip panicked with a nil dereference whenever it contained dynamic segments or fields. DynamicStruct.DynamicType is a reflect.Type excluded from JSON, so unmarshaled claims lost their generated types. DynamicStruct now implements UnmarshalJSON, rebuilding the type from the encoded field names (Field_<code>_<order>); the name-mangling helpers move from serde to the dynamic package (serde delegates to keep its API). The serializer returns an error instead of panicking if type info is still missing.

2. Repeating fields belonging to a nested slice split their parent occurrence: a second 6E reject for a single other payer created a ghost second OtherPayer, so wire 4C1/5E02 re-serialized as 4C2 with 5E1+5E1. setStructFieldByCodeTag now only grows a slice when its element type owns the field code directly (typeOwnsCode); codes owned by deeper nested slices route into the last existing element.

Documents the DynamicFields/DynamicSegments JSON shape and round-trip behavior in the schemas README.